### PR TITLE
add support for JSON Lines format in 'target'

### DIFF
--- a/glom/cli.py
+++ b/glom/cli.py
@@ -156,10 +156,10 @@ def mw_get_target(next_, posargs_, target_file, target_format, spec_file, spec_f
         try:
             try:
                 target = json.loads(target_text)
-            except Exception:  # JSONDecodeError not available in 2.7
+            except ValueError:
                 # intention: handle JSON Lines (.jsonl) format
                 target = [json.loads(line) for line in target_text.splitlines()]
-        except Exception as e:
+        except ValueError as e:
             _error('could not load target data, got: %s' % e)
     else:
         _error('expected target format to be one of python or json')

--- a/glom/cli.py
+++ b/glom/cli.py
@@ -34,12 +34,12 @@ import os
 import ast
 import sys
 import json
-from json.decoder import JSONDecodeError
 
-from face import Command, Flag, face_middleware, PosArgSpec, PosArgDisplay
+from face import Command, face_middleware, PosArgSpec
 from face.command import CommandLineError
 
 from glom import glom, Path, GlomError, Inspect
+
 
 def glom_cli(target, spec, indent, debug, inspect):
     """Command-line interface to the glom library, providing nested data
@@ -156,7 +156,7 @@ def mw_get_target(next_, posargs_, target_file, target_format, spec_file, spec_f
         try:
             try:
                 target = json.loads(target_text)
-            except JSONDecodeError:
+            except Exception:  # JSONDecodeError not available in 2.7
                 # intention: handle JSON Lines (.jsonl) format
                 target = [json.loads(line) for line in target_text.splitlines()]
         except Exception as e:


### PR DESCRIPTION
Try to read a JSON object per input line when reading the whole input as JSON fails. This makes `glom` behave more like `jq`.