### PR TITLE
Extension-friendly TargetRegistry

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -257,11 +257,6 @@ class Path(object):
                 path_t = _t_child(path_t, 'P', part)
         self.path_t = path_t
 
-    def append(self, part):
-        assert not isinstance(part, _TType), "call extend or +?"
-        assert not isinstance(part, Path), "call extend or +?"
-        self.path_t = _t_child(self.path_t, 'P', part)
-
     def _handler(self, target, scope):
         return _t_eval(self.path_t, target, scope)
 
@@ -1227,7 +1222,9 @@ class _TargetRegistry(object):
 
             if op_name in new_op_map:
                 handler = new_op_map[op_name]
-            elif target_type not in cur_type_map:
+            elif target_type in cur_type_map:
+                handler = cur_type_map[target_type]
+            else:
                 try:
                     handler = self._auto_map[op_name](target_type)
                 except Exception as e:
@@ -1253,7 +1250,7 @@ class _TargetRegistry(object):
         associated with op_name if it's supported, or False if it's
         not.
         """
-        if not isinstance(op_name, basestring) and op_name:
+        if not isinstance(op_name, basestring):
             raise TypeError('expected op_name to be a text name, not: %r' % (op_name,))
         if not callable(auto_func):
             raise TypeError('expected auto_func to be callable, not: %r' % (auto_func,))

--- a/glom/test/test_target_types.py
+++ b/glom/test/test_target_types.py
@@ -35,7 +35,7 @@ def test_types_leave_one_out():
         for t in ALL_TYPES:
             if t is cur_t:
                 continue
-            glommer.register(t, getattr)
+            glommer.register(t, get=getattr)
 
         obj = cur_t()
         assert glommer.scope[_TargetRegistry]._get_closest_type(obj) == obj.__class__.mro()[1]
@@ -64,7 +64,7 @@ def test_types_bare():
     else:
         assert False, 'expected an UnregisteredTarget exception'
 
-    glommer.register(object, getattr)
+    glommer.register(object, get=getattr)
 
     # check again that registering object for 'get' doesn't change the
     # fact that we don't have iterate support yet

--- a/glom/test/test_target_types.py
+++ b/glom/test/test_target_types.py
@@ -38,10 +38,11 @@ def test_types_leave_one_out():
             glommer.register(t, get=getattr)
 
         obj = cur_t()
-        assert glommer.scope[_TargetRegistry]._get_closest_type(obj) == obj.__class__.mro()[1]
+        treg = glommer.scope[_TargetRegistry]
+        assert treg._get_closest_type(obj, treg._op_type_tree['get']) == obj.__class__.mro()[1]
 
         if cur_t is E:
-            assert glommer.scope[_TargetRegistry]._get_closest_type(obj) is C  # sanity check
+            assert glommer.scope[_TargetRegistry]._get_closest_type(obj, treg._op_type_tree['get']) is C  # sanity check
 
     return
 
@@ -49,7 +50,8 @@ def test_types_leave_one_out():
 def test_types_bare():
     glommer = Glommer(register_default_types=False)
 
-    assert glommer.scope[_TargetRegistry]._get_closest_type(object()) is None
+    treg = glommer.scope[_TargetRegistry]
+    assert treg._get_closest_type(object(), treg._op_type_tree.get('get', {})) is None
 
     # test that bare glommers can't glom anything
     with pytest.raises(UnregisteredTarget) as exc_info:


### PR DESCRIPTION
In glom 18.2.0 there's not an extensible way to add operations beyond the builtin "get" and "iterate" (used by the Path and `[]` operators). This means that extensions like Assign are themselves not really flexible or extensible to user targets, at least not without forking.

This PR will introduce the ability to register arbitrary operations (in addition to fixing a couple other small things).