### PR TITLE
Make T (and other T types) picklable

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -721,6 +721,12 @@ class _TType(object):
     def __repr__(self):
         return _format_t(_T_PATHS[self][1:])
 
+    def __getstate__(self):
+        return tuple(_T_PATHS[self])
+
+    def __setstate__(self, state):
+        _T_PATHS[self] = state
+
 
 def _format_t(path):
     def kwarg_fmt(kw):

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -69,3 +69,19 @@ def test_path_access_error_message():
     assert ("PathAccessError: could not access 'b', part 1 of Path('a', T.b), got error: AttributeError"
             in exc_info.exconly())
     assert repr(exc_info.value) == """PathAccessError(AttributeError("\'dict\' object has no attribute \'b\'",), Path(\'a\', T.b), 1)"""
+
+
+def test_t_picklability():
+    import pickle
+
+    class TargetType(object):
+        def __init__(self):
+            self.attribute = lambda: None
+            self.attribute.method = lambda: {'key': lambda x: x * 2}
+
+    spec = T.attribute.method()['key'](x=5)
+
+    rt_spec = pickle.loads(pickle.dumps(spec))
+    assert repr(spec) == repr(rt_spec)
+
+    assert glom(TargetType(), spec) == 10


### PR DESCRIPTION
A pickled T doesn't sound like something I'd want to drink (not a fan of kombucha), but when it comes to PySpark, this PR should leave some devs tickled pink. (Pickled Tink sounds like something from a sad, gritty Peter Pan reboot)

Anyways, this PR takes a very simple approach, but should fix #48.