### PR TITLE
Path API enhancements

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -263,6 +263,16 @@ class Path(object):
     def __len__(self):
         return (len(_T_PATHS[self.path_t]) - 1) // 2
 
+    def __eq__(self, other):
+        if type(other) is Path:
+            return _T_PATHS[self.path_t] == _T_PATHS[other.path_t]
+        elif type(other) is _TType:
+            return _T_PATHS[self.path_t] == _T_PATHS[other]
+        return False
+
+    def __ne__(self, other):
+        return not self == other
+
     def pop(self, i=-1):
         # TODO: return?
         cur_t_path = _T_PATHS[self.path_t]

--- a/glom/core.py
+++ b/glom/core.py
@@ -260,6 +260,9 @@ class Path(object):
     def from_text(cls, text):
         return cls(*text.split('.'))
 
+    def __len__(self):
+        return (len(_T_PATHS[self.path_t]) - 1) // 2
+
     def glomit(self, target, scope):
         return _t_eval(target, self.path_t, scope)
 

--- a/glom/core.py
+++ b/glom/core.py
@@ -221,10 +221,10 @@ class UnregisteredTarget(GlomError):
 
 
 class Path(object):
-    """Path objects specify explicit paths when the default ``'a.b.c'``-style
-    general access syntax won't work or isn't desirable.
-    Use this to wrap ints, datetimes, and other valid keys, as well as
-    strings with dots that shouldn't be expanded.
+    """Path objects specify explicit paths when the default
+    ``'a.b.c'``-style general access syntax won't work or isn't
+    desirable. Use this to wrap ints, datetimes, and other valid
+    keys, as well as strings with dots that shouldn't be expanded.
 
     >>> target = {'a': {'b': 'c', 'd.e': 'f', 2: 3}}
     >>> glom(target, Path('a', 2))
@@ -232,10 +232,13 @@ class Path(object):
     >>> glom(target, Path('a', 'd.e'))
     'f'
 
-    Paths can also be used to join together :data:`~glom.T` objects:
+    Paths can also be used to join together other Path objects, as
+    well as :data:`~glom.T` objects:
 
     >>> Path(T['a'], T['b'])
     T['a']['b']
+    >>> Path(Path('a', 'b'), Path('c', 'd'))
+    Path('a', 'b', 'c', 'd')
 
     """
     def __init__(self, *path_parts):
@@ -258,6 +261,12 @@ class Path(object):
 
     @classmethod
     def from_text(cls, text):
+        """Make a Path from .-delimited text:
+
+        >>> Path.from_text('a.b.c')
+        Path('a', 'b', 'c')
+
+        """
         return cls(*text.split('.'))
 
     def __len__(self):
@@ -274,6 +283,11 @@ class Path(object):
         return not self == other
 
     def pop(self, i=-1):
+        """Like :meth:`list.pop()`, ``Path.pop()`` removes a segment of the
+        path object, defaulting to the last segment, modifying the
+        Path object.  Attempting to pop from an empty Path will raise
+        an :exc:`IndexError`.
+        """
         cur_t_path = _T_PATHS[self.path_t]
         if len(cur_t_path) <= 1:
             raise IndexError('pop() from empty Path')
@@ -285,6 +299,7 @@ class Path(object):
         return ret
 
     def glomit(self, target, scope):
+        # The entrypoint for the Path extension
         return _t_eval(target, self.path_t, scope)
 
     def __getitem__(self, i):

--- a/glom/core.py
+++ b/glom/core.py
@@ -312,9 +312,23 @@ class Path(object):
 
     def __getitem__(self, i):
         cur_t_path = _T_PATHS[self.path_t]
-        i = ((i * 2) + 1) if i >= 0 else ((i * 2) + len(cur_t_path))
+        try:
+            step = i.step * 2 - 1 if i.step is not None else 1
+            start = i.start if i.start is not None else 0
+            stop = i.stop
+
+            start = (start * 2) + 1 if start >= 0 else (start * 2) + len(cur_t_path)
+            if stop is not None:
+                stop = (stop * 2) + 1 if stop >= 0 else (stop * 2) + len(cur_t_path)
+        except AttributeError:
+            step = 1
+            start = (i * 2) + 1 if i >= 0 else (i * 2) + len(cur_t_path)
+            if start < 0 or start > len(cur_t_path):
+                raise IndexError('Path index out of range')
+            stop = ((i + 1) * 2) + 1 if i >= 0 else ((i + 1) * 2) + len(cur_t_path)
+
         new_t = _TType()
-        _T_PATHS[new_t] = (cur_t_path[0], cur_t_path[i], cur_t_path[i + 1])
+        _T_PATHS[new_t] = (cur_t_path[0],) + cur_t_path[start:stop:step]
         return Path(new_t)
 
     def __repr__(self):

--- a/glom/core.py
+++ b/glom/core.py
@@ -313,7 +313,7 @@ class Path(object):
     def __getitem__(self, i):
         cur_t_path = _T_PATHS[self.path_t]
         try:
-            step = i.step * 2 - 1 if i.step is not None else 1
+            step = i.step
             start = i.start if i.start is not None else 0
             stop = i.stop
 
@@ -328,7 +328,11 @@ class Path(object):
             stop = ((i + 1) * 2) + 1 if i >= 0 else ((i + 1) * 2) + len(cur_t_path)
 
         new_t = _TType()
-        _T_PATHS[new_t] = (cur_t_path[0],) + cur_t_path[start:stop:step]
+        new_path = cur_t_path[start:stop]
+        if step is not None and step != 1:
+            new_path = tuple(zip(new_path[::2], new_path[1::2]))[::step]
+            new_path = sum(new_path, ())
+        _T_PATHS[new_t] = (cur_t_path[0],) + new_path
         return Path(new_t)
 
     def __repr__(self):

--- a/glom/core.py
+++ b/glom/core.py
@@ -282,6 +282,14 @@ class Path(object):
     def __ne__(self, other):
         return not self == other
 
+    def values(self):
+        cur_t_path = _T_PATHS[self.path_t]
+        return list(cur_t_path[2::2])
+
+    def items(self):
+        cur_t_path = _T_PATHS[self.path_t]
+        return list(zip(cur_t_path[1::2], cur_t_path[2::2]))
+
     def pop(self, i=-1):
         """Like :meth:`list.pop()`, ``Path.pop()`` removes a segment of the
         path object, defaulting to the last segment, modifying the

--- a/glom/core.py
+++ b/glom/core.py
@@ -232,7 +232,7 @@ class Path(object):
     >>> glom(target, Path('a', 'd.e'))
     'f'
 
-    Paths can also be used to join together other Path objects, as
+    Paths can be used to join together other Path objects, as
     well as :data:`~glom.T` objects:
 
     >>> Path(T['a'], T['b'])
@@ -240,6 +240,14 @@ class Path(object):
     >>> Path(Path('a', 'b'), Path('c', 'd'))
     Path('a', 'b', 'c', 'd')
 
+    Paths also support indexing and slicing, with each access
+    returning a new Path object:
+
+    >>> path = Path('a', 'b', 1, 2)
+    >>> path[0]
+    Path('a')
+    >>> path[-2:]
+    Path(1, 2)
     """
     def __init__(self, *path_parts):
         path_t = T
@@ -287,10 +295,23 @@ class Path(object):
         return not self == other
 
     def values(self):
+        """
+        Returns a tuple of values referenced in this path.
+
+        >>> Path(T.a.b, 'c', T['d']).values()
+        ('a', 'b', 'c', 'd')
+        """
         cur_t_path = _T_PATHS[self.path_t]
         return cur_t_path[2::2]
 
     def items(self):
+        """
+        Returns a tuple of (operation, value) pairs.
+
+        >>> Path(T.a.b, 'c', T['d']).items()
+        (('.', 'a'), ('.', 'b'), ('P', 'c'), ('[', 'd'))
+
+        """
         cur_t_path = _T_PATHS[self.path_t]
         return tuple(zip(cur_t_path[1::2], cur_t_path[2::2]))
 

--- a/glom/core.py
+++ b/glom/core.py
@@ -294,22 +294,6 @@ class Path(object):
         cur_t_path = _T_PATHS[self.path_t]
         return tuple(zip(cur_t_path[1::2], cur_t_path[2::2]))
 
-    def pop(self, i=-1):
-        """Like :meth:`list.pop()`, ``Path.pop()`` removes a segment of the
-        path object, defaulting to the last segment, modifying the
-        Path object.  Attempting to pop from an empty Path will raise
-        an :exc:`IndexError`.
-        """
-        cur_t_path = _T_PATHS[self.path_t]
-        if len(cur_t_path) <= 1:
-            raise IndexError('pop() from empty Path')
-        i = ((i * 2) + 1) if i >= 0 else ((i * 2) + len(cur_t_path))
-        ret, new_t_path = cur_t_path[i:i + 2], cur_t_path[:i] + cur_t_path[i + 2:]
-        new_t = _TType()
-        _T_PATHS[new_t] = new_t_path
-        self.path_t = new_t
-        return ret
-
     def __getitem__(self, i):
         cur_t_path = _T_PATHS[self.path_t]
         try:

--- a/glom/core.py
+++ b/glom/core.py
@@ -274,7 +274,6 @@ class Path(object):
         return not self == other
 
     def pop(self, i=-1):
-        # TODO: return?
         cur_t_path = _T_PATHS[self.path_t]
         if len(cur_t_path) <= 1:
             raise IndexError('pop() from empty Path')
@@ -288,10 +287,11 @@ class Path(object):
     def glomit(self, target, scope):
         return _t_eval(target, self.path_t, scope)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, i):
         # used by PathAccessError
         # 1 + skips the first T/S and operator
-        return _T_PATHS[self.path_t][(1 + idx) * 2]
+        i = i if i >= 0 else i + (len(_T_PATHS[self.path_t]) - 1) // 2
+        return _T_PATHS[self.path_t][(1 + i) * 2]
 
     def __repr__(self):
         return _format_path(_T_PATHS[self.path_t][1:])

--- a/glom/core.py
+++ b/glom/core.py
@@ -263,6 +263,18 @@ class Path(object):
     def __len__(self):
         return (len(_T_PATHS[self.path_t]) - 1) // 2
 
+    def pop(self, i=-1):
+        # TODO: return?
+        cur_t_path = _T_PATHS[self.path_t]
+        if len(cur_t_path) <= 1:
+            raise IndexError('pop() from empty Path')
+        i = ((i * 2) + 1) if i >= 0 else ((i * 2) + len(cur_t_path))
+        ret, new_t_path = cur_t_path[i:i + 2], cur_t_path[:i] + cur_t_path[i + 2:]
+        new_t = _TType()
+        _T_PATHS[new_t] = new_t_path
+        self.path_t = new_t
+        return ret
+
     def glomit(self, target, scope):
         return _t_eval(target, self.path_t, scope)
 

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -37,7 +37,7 @@ class Assign(object):
             cur = _t_child(cur, segs[i], segs[i + 1])
         self.t = cur
         self.op, self.arg = segs[-2:]
-        if self.op not in '[.P':  # pragma: no cover
+        if self.op not in '[.P':
             # maybe if we add null-coalescing this should do something?
             raise ValueError('last part of path must be setattr or setitem')
         self.val = val

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -27,11 +27,11 @@ class Assign(object):
         elif not isinstance(path, Path):
             raise TypeError('path argument must be a .-delimited string, Path, T, or S')
 
-        self.path = path
         try:
-            self.op, self.arg = self.path.pop()
+            self.op, self.arg = path.items()[-1]
         except IndexError:
             raise ValueError('path must have at least one element')
+        self.path = path[:-1]
 
         if self.op not in '[.P':
             # maybe if we add null-coalescing this should do something?

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -70,3 +70,12 @@ def test_sequence_assign():
 
     with pytest.raises(TypeError):
         assign(target, 'alist.3', 4)
+    return
+
+
+def test_invalid_assign_op_target():
+    target = {'afunc': lambda x: 'hi %s' % x}
+    spec = T['afunc'](x=1)
+
+    with pytest.raises(ValueError):
+        assign(target, spec, None)

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -98,35 +98,6 @@ def test_path_len():
     assert len(Path(T.a()['b'].c.d)) == 5
 
 
-def test_path_pop():
-    with raises(IndexError, match="empty Path"):
-        Path(T).pop()
-
-    p = Path(T.a.b.c)
-    assert len(p) == 3
-    p.pop()
-    assert len(p) == 2
-    p.pop()
-    assert len(p) == 1
-    p.pop()
-    assert len(p) == 0
-
-    # sanity check
-    assert Path() == Path()
-    assert Path() != 0
-
-    p = Path(T.a.b.c)
-    p.pop(1)
-    assert len(p) == 2
-    assert p == Path(T.a.c)
-
-    p = Path(T.a.b.c)
-    res = p.pop(-2)
-    assert len(p) == 2
-    assert p == T.a.c
-    assert res == ('.', 'b')
-
-
 def test_path_getitem():
     path = Path(T.a.b.c)
 

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -130,13 +130,26 @@ def test_path_pop():
 def test_path_getitem():
     path = Path(T.a.b.c)
 
-    assert path[0] == 'a'
-    assert path[1] == 'b'
-    assert path[2] == 'c'
-    assert path[-1] == 'c'
+    assert path[0] == Path(T.a)
+    assert path[1] == Path(T.b)
+    assert path[2] == Path(T.c)
+    assert path[-1] == Path(T.c)
+    assert path[-2] == Path(T.b)
 
 
 def test_path_values():
     path = Path(T.a.b.c, 1, 2, T(test='yes'))
 
-    assert path.values() == ['a', 'b', 'c', 1, 2, ((), {'test': 'yes'})]
+    assert path.values() == ('a', 'b', 'c', 1, 2, ((), {'test': 'yes'}))
+
+    assert Path().values() == ()
+
+
+def test_path_items():
+    path = Path(T.a, 1, 2, T(test='yes'))
+
+    assert path.items() == (('.', 'a'),
+                            ('P', 1), ('P', 2),
+                            ('(', ((), {'test': 'yes'})))
+
+    assert Path().items() == ()

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -111,13 +111,17 @@ def test_path_pop():
     p.pop()
     assert len(p) == 0
 
+    # sanity check
+    assert Path() == Path()
+    assert Path() != 0
+
     p = Path(T.a.b.c)
     p.pop(1)
     assert len(p) == 2
-    assert repr(p) == 'T.a.c'
+    assert p == Path(T.a.c)
 
     p = Path(T.a.b.c)
     res = p.pop(-2)
     assert len(p) == 2
-    assert repr(p) == 'T.a.c'
+    assert p == T.a.c
     assert res == ('.', 'b')

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -96,3 +96,28 @@ def test_path_len():
     assert len(Path(T)) == 0
     assert len(Path(T.a.b.c)) == 3
     assert len(Path(T.a()['b'].c.d)) == 5
+
+
+def test_path_pop():
+    with raises(IndexError, match="empty Path"):
+        Path(T).pop()
+
+    p = Path(T.a.b.c)
+    assert len(p) == 3
+    p.pop()
+    assert len(p) == 2
+    p.pop()
+    assert len(p) == 1
+    p.pop()
+    assert len(p) == 0
+
+    p = Path(T.a.b.c)
+    p.pop(1)
+    assert len(p) == 2
+    assert repr(p) == 'T.a.c'
+
+    p = Path(T.a.b.c)
+    res = p.pop(-2)
+    assert len(p) == 2
+    assert repr(p) == 'T.a.c'
+    assert res == ('.', 'b')

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -165,6 +165,9 @@ def test_path_slices():
     # negative indices backwards
     assert path[-1:-3] == Path()
 
+    # slicing and stepping
+    assert path[1::2] == Path(T.b, 2)
+
 
 def test_path_values():
     path = Path(T.a.b, 1, 2, T(test='yes'))

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -136,11 +136,40 @@ def test_path_getitem():
     assert path[-1] == Path(T.c)
     assert path[-2] == Path(T.b)
 
+    with raises(IndexError, match='Path index out of range'):
+        path[4]
+
+    with raises(IndexError, match='Path index out of range'):
+        path[-14]
+    return
+
+
+def test_path_slices():
+    path = Path(T.a.b, 1, 2, T(test='yes'))
+
+    assert path[::] == path
+
+    # positive indices
+    assert path[3:] == Path(2, T(test='yes'))
+    assert path[1:3] == Path(T.b, 1)
+    assert path[:3] == Path(T.a.b, 1)
+
+    # positive indices backwards
+    assert path[2:1] == Path()
+
+    # negative indices forward
+    assert path[-1:] == Path(T(test='yes'))
+    assert path[:-2] == Path(T.a.b, 1)
+    assert path[-3:-1] == Path(1, 2)
+
+    # negative indices backwards
+    assert path[-1:-3] == Path()
+
 
 def test_path_values():
-    path = Path(T.a.b.c, 1, 2, T(test='yes'))
+    path = Path(T.a.b, 1, 2, T(test='yes'))
 
-    assert path.values() == ('a', 'b', 'c', 1, 2, ((), {'test': 'yes'}))
+    assert path.values() == ('a', 'b', 1, 2, ((), {'test': 'yes'}))
 
     assert Path().values() == ()
 

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -85,3 +85,14 @@ def test_t_picklability():
     assert repr(spec) == repr(rt_spec)
 
     assert glom(TargetType(), spec) == 10
+
+
+def test_path_len():
+
+    assert len(Path()) == 0
+    assert len(Path('a', 'b', 'c')) == 3
+    assert len(Path.from_text('1.2.3.4')) == 4
+
+    assert len(Path(T)) == 0
+    assert len(Path(T.a.b.c)) == 3
+    assert len(Path(T.a()['b'].c.d)) == 5

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -125,3 +125,12 @@ def test_path_pop():
     assert len(p) == 2
     assert p == T.a.c
     assert res == ('.', 'b')
+
+
+def test_path_getitem():
+    path = Path(T.a.b.c)
+
+    assert path[0] == 'a'
+    assert path[1] == 'b'
+    assert path[2] == 'c'
+    assert path[-1] == 'c'

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -134,3 +134,9 @@ def test_path_getitem():
     assert path[1] == 'b'
     assert path[2] == 'c'
     assert path[-1] == 'c'
+
+
+def test_path_values():
+    path = Path(T.a.b.c, 1, 2, T(test='yes'))
+
+    assert path.values() == ['a', 'b', 'c', 1, 2, ((), {'test': 'yes'})]


### PR DESCRIPTION
Various enhancements to Path to make it a more useful building block for extensions:

- `len(path)`
- `path.pop([i])`
- `path == other_path`

The above all do reasonable things, and I'm considering updating `Path.__getitem__()` to also be more useful, possibly, by including the Path op, not just the argument.

Other ideas?

Update: redid it so that Path is more immutable now (no more `.pop()`, slice syntax instead, with `.values()` and `.items()`).