### PR TITLE
PathAssignError

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,23 @@ specifiers to declare away overly branchy procedural code.
 
 .. autodata:: glom.OMIT
 
+Target mutation with Assign
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+*New in glom 18.3.0*
+
+Most of glom's API design defaults to safely copying your data. But
+such caution isn't always justified.
+
+When you already have a large or complex bit of nested data that you
+are sure you want to modify in-place, glom has you covered, with the
+:func:`~glom.assign` function, and the :func:`~glom.Assign` specifier
+type.
+
+.. autofunction:: glom.assign
+
+.. autoclass:: glom.Assign
+
 
 Reducing lambda usage with Call
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -114,6 +114,8 @@ other standard Python exceptions as appropriate.
 
 .. autoclass:: glom.UnregisteredTarget
 
+.. autoclass:: glom.PathAssignError
+
 .. autoclass:: glom.GlomError
 
 .. _debugging:

--- a/glom/__init__.py
+++ b/glom/__init__.py
@@ -17,4 +17,4 @@ from glom.core import (glom,
                        UnregisteredTarget,
                        T, S)
 
-from glom.mutable import Assign, assign
+from glom.mutable import Assign, assign, PathAssignError

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -20,34 +20,45 @@ if getattr(__builtins__, '__dict__', None):
 
 
 class Assign(object):
-    """The Assign specifier type enables glom to modify the target,
+    """The ``Assign`` specifier type enables glom to modify the target,
     performing a "deep-set" to mirror glom's original deep-get use
     case.
 
-    Assign can be used to perform spot modifications of large data
-    structures when making a copy is not desirable.
+    ``Assign`` can be used to perform spot modifications of large data
+    structures when making a copy is not desired::
 
-    >>> target = {'a': {}}
-    >>> spec = Assign('a.b', 'value')
-    >>> _ = glom(target, spec)
-    >>> pprint(target)
-    {'a': {'b': 'value'}}
+      # deep assignment into a nested dictionary
+      >>> target = {'a': {}}
+      >>> spec = Assign('a.b', 'value')
+      >>> _ = glom(target, spec)
+      >>> pprint(target)
+      {'a': {'b': 'value'}}
 
-    The value to be assigned can also be a Spec, which is useful for
-    copying values around within the data structure.
+    The value to be assigned can also be a :class:`~glom.Spec`, which
+    is useful for copying values around within the data structure::
 
-    >>> _ = glom(target, Assign('a.c', Spec('a.b')))
-    >>> pprint(target)
-    {'a': {'b': 'value', 'c': 'value'}}
+      # copying one nested value to another
+      >>> _ = glom(target, Assign('a.c', Spec('a.b')))
+      >>> pprint(target)
+      {'a': {'b': 'value', 'c': 'value'}}
 
-    The target path can be a :data:`~glom.T` expression, for maximum control:
+    Like many other specifier types, ``Assign``'s destination path can be
+    a :data:`~glom.T` expression, for maximum control::
 
-    >>> err = ValueError('initial message')
-    >>> target = {'errors': [err]}
-    >>> _ = glom(target, Assign(T['errors'][0].args, ('new message',)))
-    >>> str(err)
-    'new message'
+      # changing the error message of an exception in an error list
+      >>> err = ValueError('initial message')
+      >>> target = {'errors': [err]}
+      >>> _ = glom(target, Assign(T['errors'][0].args, ('new message',)))
+      >>> str(err)
+      'new message'
 
+    ``Assign`` has built-in support for assigning to attributes of
+    objects, keys of mappings (like dicts), and indexes of sequences
+    (like lists). Additional types can be registered through
+    :func:`~glom.register()` using the ``"set"`` operation name.
+
+    Attempting to assign to an immutable structure, like a
+    :class:`tuple`, will result in a :class:`~glom.PathAccessError`.
     """
     def __init__(self, path, val):
         # TODO: an option like require_preexisting or something to
@@ -99,6 +110,18 @@ class Assign(object):
 
 
 def assign(obj, path, val):
+    """The ``assign()`` function provides convenient "deep set"
+    functionality, modifying nested data structures in-place::
+
+      >>> target = {'a': [{'b': 'c'}, {'d': None}]}
+      # let's give 'd' a value of 'e'
+      >>> _ = assign(target, 'a.1.d', 'e')
+      >>> pprint(target)
+      {'a': [{'b': 'c'}, {'d': 'e'}]}
+
+    For more information and examples, see the :class:`~glom.Assign`
+    specifier type, which this function wraps.
+    """
     return glom(obj, Assign(path, val))
 
 

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from glom import glom, Path, T, Spec, Glommer
+from glom import glom, Path, T, Spec, Glommer, PathAssignError
 from glom.core import UnregisteredTarget
 from glom.mutable import Assign, assign
 
@@ -24,10 +24,10 @@ def test_assign():
     assert glom(r(), Assign(T['r']['r']['r']['r'], 1)) == {'r': 1}
     assert glom(r(), Assign(Path('r', 'r', T['r']), 1)) == {'r': 1}
     assert assign(r(), Path('r', 'r', T['r']), 1) == {'r': 1}
-    with pytest.raises(TypeError):
-        glom({}, Assign(1, 'a'))
-    with pytest.raises(ValueError):
-        glom({}, Assign(T, 1))
+    with pytest.raises(TypeError, match='path argument must be'):
+        Assign(1, 'a')
+    with pytest.raises(ValueError, match='path must have at least one element'):
+        Assign(T, 1)
 
 
 def test_assign_spec_val():
@@ -58,7 +58,7 @@ def test_bad_assign_target():
     glom(ok_target, spec)
     assert ok_target.a == 'b'
 
-    with pytest.raises(TypeError, match='failed to assign'):
+    with pytest.raises(PathAssignError, match='could not assign'):
         glom(BadTarget(), spec)
     return
 
@@ -68,7 +68,7 @@ def test_sequence_assign():
     assign(target, 'alist.2', 3)
     assert target['alist'][2] == 3
 
-    with pytest.raises(TypeError):
+    with pytest.raises(PathAssignError, match='could not assign'):
         assign(target, 'alist.3', 4)
     return
 

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -68,8 +68,17 @@ def test_sequence_assign():
     assign(target, 'alist.2', 3)
     assert target['alist'][2] == 3
 
-    with pytest.raises(PathAssignError, match='could not assign'):
+    with pytest.raises(PathAssignError, match='could not assign') as exc_info:
         assign(target, 'alist.3', 4)
+
+    # the following test is because pypy's IndexError is different than CPython's:
+    # E         - PathAssignError(IndexError('list index out of range',), Path('alist'), '3')
+    # E         + PathAssignError(IndexError('list assignment index out of range',), Path('alist'), '3')
+    # E         ?                                  +++++++++++
+
+    exc_repr = repr(exc_info.value)
+    assert exc_repr.startswith('PathAssignError(')
+    assert exc_repr.endswith("'3')")
     return
 
 


### PR DESCRIPTION
At the moment, a failing assignment (using `assign()`) raises a `TypeError`. This goes against the convention of raising a `GlomError` subtype for runtime glom exceptions. This PR remedies this with a new error type: `PathAssignError`, somewhat corresponding to `PathAccessError`.