### PR TITLE
Return an informative error message when spec should be a list

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -1116,7 +1116,16 @@ class _AbstractIterable(_AbstractIterableBase):
 
 
 def _get_sequence_item(target, index):
-    return target[int(index)]
+    try:
+        return target[int(index)]
+    except ValueError as e:
+        if 'invalid literal for int() with base 10:' in str(e):
+            msg = ("Error indexing the target. This can happen when your "
+                   "target is a list and your spec is not. Did you forget "
+                   "to put brackets around your spec?")
+            raise ValueError(msg)
+        else:
+            raise e
 
 
 # handlers are 3-arg callables, with args (spec, target, scope)


### PR DESCRIPTION
`glom` is great, thanks for making it!

This PR makes the error message more informative when your target is a list and your spec is not.

Currently when target is a list but spec is not you get

`ValueError: invalid literal for int() with base 10:`

which doesn't immediately suggest that you forgot to make your spec a list. I've run into this a couple times now, and each time I forgot about last time and ended up having to check the source code to figure out what was going on. Next time I might finally remember, but for other people hitting this a different error message might help. With this change, the error message is

`ValueError: Error indexing the target. This can happen when your target is a list and your spec is not. Did you forget to put brackets around your spec?`

Please let me know if this check makes more sense somewhere else, I just put it right where the error first gets raised.

Thanks!

MWE:
```
from glom import glom

target = [{'xxx': i} for i in range(3)]

spec = {'number': 'xxx'}

glom(target, spec)
```