### PR TITLE
Add missing parameter to assign()

### DIFF
--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -101,10 +101,6 @@ class Assign(object):
        >>> assign(target, 'a.b.c', 'hi', missing=dict)
        {'a': {'b': {'c': 'hi'}}}
 
-    Note that because using the *missing* option performs multiple
-    assignments, a failure can leave your target object in a partially
-    modified state.
-
     """
     def __init__(self, path, val, missing=None):
         # TODO: an option like require_preexisting or something to

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -88,7 +88,9 @@ class Assign(object):
     :func:`~glom.register()` using the ``"assign"`` operation name.
 
     Attempting to assign to an immutable structure, like a
-    :class:`tuple`, will result in a :class:`~glom.PathAssignError`.
+    :class:`tuple`, will result in a
+    :class:`~glom.PathAssignError`. Attempting to assign to a path
+    that doesn't exist will raise a :class:`~PathAccessError`.
 
     To automatically backfill missing structures, you can pass a
     callable to the *missing* argument. This callable will be called
@@ -99,9 +101,9 @@ class Assign(object):
        >>> assign(target, 'a.b.c', 'hi', missing=dict)
        {'a': {'b': {'c': 'hi'}}}
 
-    Note that because using this option performs multiple assignments,
-    a failure can leave your target object in a partially modified
-    state.
+    Note that because using the *missing* option performs multiple
+    assignments, a failure can leave your target object in a partially
+    modified state.
 
     """
     def __init__(self, path, val, missing=None):

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -144,7 +144,7 @@ class Assign(object):
                 raise
 
             remaining_path = self._orig_path[pae.part_idx + 1:]
-            val = assign(self.missing(), remaining_path, val, missing=self.missing)
+            val = scope[glom](self.missing(), Assign(remaining_path, val, missing=self.missing), scope)
 
             op, arg = self._orig_path.items()[pae.part_idx]
             path = self._orig_path[:pae.part_idx]
@@ -164,7 +164,7 @@ class Assign(object):
             try:
                 _assign(dest, arg, val)
             except Exception as e:
-                raise PathAssignError(e, path, arg)  # TODO: path
+                raise PathAssignError(e, path, arg)
 
         return target
 

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -169,19 +169,6 @@ class Assign(object):
         return target
 
 
-
-def _backfill_path(default_factory, target, path, path_idx=0):
-    """Used by Assign to create missing container objects along the
-    path. *default_factory* is the *missing* parameter of
-    Assign/assign(), and is used much the same as the first parameter
-    to collections.defaultdict.
-    """
-    for idx in range(path_idx, len(path)):
-        cur_path = path[:idx + 1]
-        assign(target, cur_path, default_factory())
-    return
-
-
 def assign(obj, path, val, missing=None):
     """The ``assign()`` function provides convenient "deep set"
     functionality, modifying nested data structures in-place::

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -111,3 +111,6 @@ def test_assign_missing():
 
     assert target.a.b.c.d is val
     assert target.a is extant_a  # make sure we didn't overwrite anything on the path
+
+    with pytest.raises(TypeError, match='callable'):
+        assign({}, 'a.b.c', 'lol', missing='invalidbcnotcallable')

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from glom import glom, Path, T, Spec, Glommer, PathAssignError
+from glom import glom, Path, T, Spec, Glommer, PathAssignError, PathAccessError
 from glom.core import UnregisteredTarget
 from glom.mutable import Assign, assign
 
@@ -60,6 +60,9 @@ def test_bad_assign_target():
 
     with pytest.raises(PathAssignError, match='could not assign'):
         glom(BadTarget(), spec)
+
+    with pytest.raises(PathAccessError, match='could not access'):
+        assign({}, 'a.b.c', 'moot')
     return
 
 

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -88,3 +88,23 @@ def test_invalid_assign_op_target():
 
     with pytest.raises(ValueError):
         assign(target, spec, None)
+    return
+
+
+def test_assign_missing():
+    target = {}
+
+    val = object()
+    assign(target, 'a.b.c.d', val, missing=dict)
+
+    assert target == {'a': {'b': {'c': {'d': val}}}}
+
+    class Container(object):
+        pass
+
+    target = Container()
+    target.a = extant_a = Container()
+    assign(target, 'a.b.c.d', val, missing=Container)
+
+    assert target.a.b.c.d is val
+    assert target.a is extant_a  # make sure we didn't overwrite anything on the path


### PR DESCRIPTION
To resolve #13, this change introduces the `missing` parameter to the `Assign` spec and `assign()` convenience function. Missing data structures along the way will be backfilled by calling this callable without arguments.

```python
       >>> target = {}
       >>> assign(target, 'a.b.c', 'hi', missing=dict)
       {'a': {'b': {'c': 'hi'}}}
```

Basically tested working, pretty neat overall. It's a little bit dangerous because some corner cases can lead to partial writes, and I am vaguely concerned that the heuristic of looking for a `PathAccessError` might clobber something. But overall seems worth the risk to me! 

Sidenote: The `T`-based path made this much easier than expected, felt good!