### PR TITLE
working on assigning s

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -266,8 +266,16 @@ class Path(object):
     Path(1, 2)
     """
     def __init__(self, *path_parts):
-        path_t = T
-        for part in path_parts:
+        if not path_parts:
+            self.path_t = T
+            return
+        if isinstance(path_parts[0], TType):
+            path_t = path_parts[0]
+            offset = 1
+        else:
+            path_t = T
+            offset = 0
+        for part in path_parts[offset:]:
             if isinstance(part, Path):
                 part = part.path_t
             if isinstance(part, TType):
@@ -811,37 +819,14 @@ class TType(object):
         return _t_child(self, '(', (args, kwargs))
 
     def __repr__(self):
-        return _format_t(_T_PATHS[self][1:])
+        t_path = _T_PATHS[self]
+        return _format_t(t_path[1:], t_path[0])
 
     def __getstate__(self):
         return tuple(_T_PATHS[self])
 
     def __setstate__(self, state):
         _T_PATHS[self] = state
-
-
-def _format_t(path):
-    def kwarg_fmt(kw):
-        if isinstance(kw, str):
-            return kw
-        return repr(kw)
-    prepr = ['T']
-    i = 0
-    while i < len(path):
-        op, arg = path[i], path[i + 1]
-        if op == '.':
-            prepr.append('.' + arg)
-        elif op == '[':
-            prepr.append("[%r]" % (arg,))
-        elif op == '(':
-            args, kwargs = arg
-            prepr.append("(%s)" % ", ".join([repr(a) for a in args] +
-                                            ["%s=%r" % (kwarg_fmt(k), v)
-                                             for k, v in kwargs.items()]))
-        elif op == 'P':
-            return _format_path(path)
-        i += 2
-    return "".join(prepr)
 
 
 _T_PATHS = weakref.WeakKeyDictionary()
@@ -907,6 +892,30 @@ S = TType()  # like T, but means grab stuff from Scope, not Target
 _T_PATHS[T] = (T,)
 _T_PATHS[S] = (S,)
 UP = make_sentinel('UP')
+
+
+def _format_t(path, root=T):
+    def kwarg_fmt(kw):
+        if isinstance(kw, str):
+            return kw
+        return repr(kw)
+    prepr = ['T' if root is T else 'S']
+    i = 0
+    while i < len(path):
+        op, arg = path[i], path[i + 1]
+        if op == '.':
+            prepr.append('.' + arg)
+        elif op == '[':
+            prepr.append("[%r]" % (arg,))
+        elif op == '(':
+            args, kwargs = arg
+            prepr.append("(%s)" % ", ".join([repr(a) for a in args] +
+                                            ["%s=%r" % (kwarg_fmt(k), v)
+                                             for k, v in kwargs.items()]))
+        elif op == 'P':
+            return _format_path(path)
+        i += 2
+    return "".join(prepr)
 
 
 class CheckError(GlomError):
@@ -1424,6 +1433,7 @@ def glom(target, spec, **kwargs):
 def _glom(target, spec, scope):
     scope = scope.new_child()
     scope[T] = target
+    scope['spec'] = spec
 
     if isinstance(spec, TType):  # must go first, due to callability
         return _t_eval(target, spec, scope)

--- a/glom/core.py
+++ b/glom/core.py
@@ -823,10 +823,11 @@ class TType(object):
         return _format_t(t_path[1:], t_path[0])
 
     def __getstate__(self):
-        return tuple(_T_PATHS[self])
+        t_path = _T_PATHS[self]
+        return tuple(('T' if t_path[0] is T else 'S',) + t_path[1:])
 
     def __setstate__(self, state):
-        _T_PATHS[self] = state
+        _T_PATHS[self] = (T if state[0] == 'T' else S,) + state[1:]
 
 
 _T_PATHS = weakref.WeakKeyDictionary()
@@ -1433,7 +1434,7 @@ def glom(target, spec, **kwargs):
 def _glom(target, spec, scope):
     scope = scope.new_child()
     scope[T] = target
-    scope['spec'] = spec
+    scope[Spec] = spec
 
     if isinstance(spec, TType):  # must go first, due to callability
         return _t_eval(target, spec, scope)

--- a/glom/core.py
+++ b/glom/core.py
@@ -339,6 +339,25 @@ class Path(object):
         cur_t_path = _T_PATHS[self.path_t]
         return tuple(zip(cur_t_path[1::2], cur_t_path[2::2]))
 
+    def startswith(self, other):
+        if isinstance(other, basestring):
+            other = Path(other)
+        if isinstance(other, Path):
+            other = other.path_t
+        if not isinstance(other, TType):
+            raise TypeError('can only check if Path starts with string, Path or T')
+        o_path = _T_PATHS[other]
+        return _T_PATHS[self.path_t][:len(o_path)] == o_path
+
+    def from_t(self):
+        '''return the same path but starting from T'''
+        t_path = _T_PATHS[self.path_t]
+        if t_path[0] is S:
+            new_t = TType()
+            _T_PATHS[new_t] = (T,) + t_path[1:]
+            return Path(new_t)
+        return self
+
     def __getitem__(self, i):
         cur_t_path = _T_PATHS[self.path_t]
         try:

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -131,6 +131,7 @@ class Assign(object):
         self.missing = missing
 
     def glomit(self, target, scope):
+        scope = scope.parents  # reset scope to parent scope so changes are visible
         if type(self.val) is Spec:
             val = scope[glom](target, self.val, scope)
         else:
@@ -150,6 +151,7 @@ class Assign(object):
             path = self._orig_path[:pae.part_idx]
             dest = scope[glom](target, path, scope)
 
+        import pdb; pdb.set_trace()
         # TODO: forward-detect immutable dest?
         if op == '[':
             dest[arg] = val

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -131,15 +131,20 @@ class Assign(object):
         self.missing = missing
 
     def glomit(self, target, scope):
-        scope = scope.parents  # reset scope to parent scope so changes are visible
         if type(self.val) is Spec:
             val = scope[glom](target, self.val, scope)
         else:
             val = self.val
 
         op, arg, path = self.op, self.arg, self.path
+        if self.path.startswith(S):
+            dest_target = scope.parents
+            dest_path = self.path.from_t()
+        else:
+            dest_target = target
+            dest_path = self.path
         try:
-            dest = scope[glom](target, self.path, scope)
+            dest = scope[glom](dest_target, dest_path, scope)
         except PathAccessError as pae:
             if not self.missing:
                 raise
@@ -149,7 +154,7 @@ class Assign(object):
 
             op, arg = self._orig_path.items()[pae.part_idx]
             path = self._orig_path[:pae.part_idx]
-            dest = scope[glom](target, path, scope)
+            dest = scope[glom](dest_target, path, scope)
 
         # TODO: forward-detect immutable dest?
         if op == '[':

--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -151,7 +151,6 @@ class Assign(object):
             path = self._orig_path[:pae.part_idx]
             dest = scope[glom](target, path, scope)
 
-        import pdb; pdb.set_trace()
         # TODO: forward-detect immutable dest?
         if op == '[':
             dest[arg] = val

--- a/glom/test/test_mutable.py
+++ b/glom/test/test_mutable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from glom import glom, Path, T, Spec, Glommer, PathAssignError, PathAccessError
+from glom import glom, Path, T, S, Spec, Glommer, PathAssignError, PathAccessError
 from glom.core import UnregisteredTarget
 from glom.mutable import Assign, assign
 
@@ -184,3 +184,10 @@ def test_assign_missing_unassignable():
     # unassignable is already present, but not possible to assign to,
     # raising the PathAssignError.
     assert Tarjay.init_count == 3
+
+
+def test_s_assign():
+    '''
+    check that assign works when storing things into S
+    '''
+    glom({}, (Assign(S['foo'], 'bar'), S['foo']))

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -171,3 +171,26 @@ def test_path_eq():
 def test_path_eq_t():
     assert Path(T.a.b) == T.a.b
     assert Path(T.a.b.c) != T.a.b
+
+
+def test_startswith():
+    ref = T.a.b[1]
+
+    assert Path(ref).startswith(T)
+    assert Path(ref).startswith(T.a.b)
+    assert Path(ref).startswith(ref)
+    assert Path(ref).startswith(ref.c) is False
+
+    assert Path('a.b.c').startswith(Path())
+    assert Path('a.b.c').startswith('a.b.c')
+
+    with raises(TypeError):
+        assert Path('a.b.c').startswith(None)
+
+    return
+
+
+def test_from_t_identity():
+    ref = Path(T.a.b)
+    assert ref.from_t() == ref
+    assert ref.from_t() is ref

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -86,6 +86,9 @@ def test_t_picklability():
 
     assert glom(TargetType(), spec) == 10
 
+    s_spec = S.attribute
+    assert repr(s_spec) == repr(pickle.loads(pickle.dumps(s_spec)))
+
 
 def test_path_len():
 

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -1,7 +1,7 @@
 
 from pytest import raises
 
-from glom import glom, Path, T, PathAccessError, GlomError
+from glom import glom, Path, S, T, PathAccessError, GlomError
 
 def test_list_path_access():
     assert glom(list(range(10)), Path(1)) == 1


### PR DESCRIPTION
```(glom) C:\Users\kurt\workspace\glom>python -c "from glom import glom, S, Assign; glom({}, (Assign(S['foo'], 'bar'), S['foo']))"
> c:\users\kurt\workspace\glom\glom\mutable.py(156)glomit()
-> if op == '[':
(Pdb) dest
ChainMap({T: {}, 'spec': Path()}, {T: {}, 'spec': (<glom.mutable.Assign object at 0x0000000002E73550>, S['foo'])}, {<class 'glom.core.Inspect'>: None, <class 'glom.core.Path'>: []}, {<function glom at 0x00000000031D1668>: <function _glom at 0x00000000031D1AC8>, <class 'glom.core.TargetRegistry'>: <glom.core.TargetRegistry object at 0x00000000031D2438>})```

not sure why scope parents seems to have that extra Path() thingie at the end