### PR TITLE
Automate raising of UnregisteredTarget exception

### DIFF
--- a/glom/mutable.py
+++ b/glom/mutable.py
@@ -171,10 +171,6 @@ class Assign(object):
             setattr(dest, arg, val)
         elif op == 'P':
             _assign = scope[TargetRegistry].get_handler('assign', dest)
-            if not _assign:
-                raise UnregisteredTarget('assign', type(dest),
-                                         scope[TargetRegistry].get_type_map('assign'),
-                                         path=scope[Path])
             try:
                 _assign(dest, arg, val)
             except Exception as e:


### PR DESCRIPTION
Rewrite TargetHandler interaction so that it automatically raises an UnregisteredTarget when there's no registered target. 

Might add a default argument in the future, but right now it's not needed. Right now everywhere has to raise its own UnregisteredTarget and there are no cases of default behavior on UnregisteredTarget (plus it's easy to just catch the exception).

The one disadvantage is that the caller now has to pass in the path for the best-possible exception, but it seems better than having to correctly construct the whole exception yourself.