### PR TITLE
Delete mutation

### DIFF
--- a/glom/__init__.py
+++ b/glom/__init__.py
@@ -26,7 +26,7 @@ from glom.core import (glom,
                        T, S)
 
 from glom.reduction import Sum, Fold, Flatten, flatten, FoldError, Merge, merge
-from glom.mutation import Assign, assign, PathAssignError
+from glom.mutation import Assign, Delete, assign, delete, PathAssignError, PathDeleteError
 
 # there's no -ion word that really fits what "streaming" means.
 # generation, production, iteration, all have more relevant meanings

--- a/glom/mutation.py
+++ b/glom/mutation.py
@@ -49,6 +49,13 @@ class PathAssignError(GlomError):
                 % (self.dest_name, self.path, self.exc))
 
 
+class PathDeleteError(PathAssignError):
+    def __str__(self):
+        return ('could not delete %r on object at %r, got error: %r'
+                % (self.dest_name, self.path, self.exc))
+
+
+
 class Assign(object):
     """The ``Assign`` specifier type enables glom to modify the target,
     performing a "deep-set" to mirror glom's original deep-get use
@@ -230,11 +237,11 @@ register_op('assign', auto_func=_assign_autodiscover, exact=False)
 
 
 class Delete(object):
-    def __ini__(self, path, ignore_missing=False):
+    def __init__(self, path, ignore_missing=False):
         if isinstance(path, basestring):
             path = Path.from_text(path)
         elif type(path) is TType:
-            path - Path(path)
+            path = Path(path)
         elif not isinstance(path, Path):
             raise TypeError('path argument must be a .-delimited string, Path, T, or S')
 
@@ -264,11 +271,25 @@ class Delete(object):
             if not self.ignore_missing:
                 raise
         else:
-            try:
-                del dest[arg]
-            except (KeyError, IndexError):
-                if not self.ignore_missing:
-                    raise
+            if op == '[':
+                try:
+                    del dest[arg]
+                except IndexError as e:
+                    if not self.ignore_missing:
+                        raise PathDeleteError(e, path, arg)
+            elif op == '.':
+                try:
+                    delattr(dest, arg)
+                except AttributeError as e:
+                    if not self.ignore_missing:
+                        raise PathDeleteError(e, path, arg)
+            elif op == 'P':
+                _delete = scope[TargetRegistry].get_handler('delete', dest)
+                try:
+                    _delete(dest, arg)
+                except Exception as e:
+                    if not self.ignore_missing:
+                        raise PathDeleteError(e, path, arg)
 
         return target
 
@@ -277,5 +298,23 @@ class Delete(object):
         return '%s(%r)' % (cn, self._orig_path)
 
 
-def delete(obj, path, ignore_missing=True):
+def delete(obj, path, ignore_missing=False):
     return glom(obj, Delete(path, ignore_missing=ignore_missing))
+
+
+def _del_sequence_item(target, idx):
+    del target[int(idx)]
+
+
+def _delete_autodiscover(type_obj):
+    if issubclass(type_obj, _UNASSIGNABLE_BASE_TYPES):
+        return False
+
+    if callable(getattr(type_obj, '__delitem__', None)):
+        if callable(getattr(type_obj, 'index', None)):
+            return _del_sequence_item
+        return operator.delitem
+    return delattr
+
+
+register_op('delete', auto_func=_delete_autodiscover, exact=False)

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from glom import glom, Path, T, S, Spec, Glommer, PathAssignError, PathAccessError
-from glom import assign, Assign, PathAssignError
+from glom import assign, Assign, delete, Delete, PathAssignError, PathDeleteError
 from glom.core import UnregisteredTarget
 
 
@@ -194,3 +194,91 @@ def test_s_assign():
     check that assign works when storing things into S
     '''
     glom({}, (Assign(S['foo'], 'bar'), S['foo'])) == 'bar'
+
+
+def test_delete():
+    class Foo(object):
+        def __init__(self, d=None):
+            for k, v in d.items():
+                setattr(self, k, v)
+
+    assert glom({'a': 1}, Delete(T['a'])) == {}
+    assert glom({'a': {'a': 1}}, Delete(T['a']['a'])) == {'a': {}}
+    assert glom({'a': {'a': 1}}, Delete('a.a')) == {'a': {}}
+    assert not hasattr(glom(Foo({'a': 1}), Delete(T.a)), 'a')
+    assert glom({'a': 1}, Delete('a')) == {}
+    assert not hasattr(glom(Foo({'a': 1}), Delete('a')), 'a')
+    assert not hasattr(glom({'a': Foo({'a': 1})}, Delete('a.a'))['a'], 'a')
+
+    def r():
+        r = {}
+        r['r'] = r
+        return r
+
+    assert glom(r(), Delete('r.r.r.r.r.r.r.r.r')) == {}
+    assert glom(r(), Delete(T['r']['r']['r']['r'])) == {}
+    assert glom(r(), Delete(Path('r', 'r', T['r']))) == {}
+    assert delete(r(), Path('r', 'r', T['r'])) == {}
+    with pytest.raises(TypeError, match='path argument must be'):
+        Delete(1, 'a')
+    with pytest.raises(ValueError, match='path must have at least one element'):
+        Delete(T, 1)
+
+    assert repr(Delete(T.a)) == 'Delete(T.a)'
+
+
+def test_unregistered_delete():
+    glommer = Glommer(register_default_types=False)
+
+    with pytest.raises(UnregisteredTarget, match='delete'):
+        glommer.glom({'a': 1}, Delete('a'))
+
+    with pytest.raises(UnregisteredTarget, match='delete'):
+        glom({'a': (1,)}, Delete('a.0'))
+
+
+def test_bad_delete_target():
+    class BadTarget(object):
+        def __delattr__(self, name):
+            raise Excetpion("and you trusted me?")
+
+    spec = Delete('a')
+    ok_target = lambda: None
+    ok_target.a = 1
+    glom(ok_target, spec)
+    assert not hasattr(ok_target, 'a')
+
+    with pytest.raises(PathDeleteError, match='could not delete'):
+        glom(BadTarget(), spec)
+
+    with pytest.raises(PathDeleteError, match='could not delete'):
+        delete({}, 'a')
+    return
+
+
+def test_sequence_delete():
+    target = {'alist': [0, 1, 2]}
+    delete(target, 'alist.1')
+    assert target['alist'] == [0, 2]
+
+    with pytest.raises(PathDeleteError, match='could not delete') as exc_info:
+        delete(target, 'alist.2')
+
+    exc_repr = repr(exc_info.value)
+    assert exc_repr.startswith('PathDeleteError(')
+    assert exc_repr.endswith("'2')")
+    return
+
+
+def test_invalid_delete_op_target():
+    target = {'afunc': lambda x: 'hi %s' % x}
+    spec = T['afunc'](x=1)
+
+    with pytest.raises(ValueError):
+        delete(target, spec, None)
+    return
+
+
+def test_delete_ignore_missing():
+    assert delete({}, 'a', ignore_missing=True) == {}
+    assert delete({}, 'a.b', ignore_missing=True) == {}


### PR DESCRIPTION
I don't know if this has been brought up/discussed before, but I needed something that can do deletions of keys within a target.

I don't fully understand the how glom works (particularly Ts and Ss), but I seem to have cobbled together that passes unit tests.

Usage:
```
import glom

target = {'a': {'b': 1}}
assert glom.delete(target, 'a.b') == {'a': {}}
```