### PR TITLE
Better builtin roundtripping

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -1227,10 +1227,6 @@ class Let(object):
 
 
 def _format_t(path, root=T):
-    def kwarg_fmt(kw):
-        if isinstance(kw, str):
-            return kw
-        return repr(kw)
     prepr = ['T' if root is T else 'S']
     i = 0
     while i < len(path):
@@ -1238,12 +1234,10 @@ def _format_t(path, root=T):
         if op == '.':
             prepr.append('.' + arg)
         elif op == '[':
-            prepr.append("[%r]" % (arg,))
+            prepr.append("[%s]" % (bbrepr(arg),))
         elif op == '(':
             args, kwargs = arg
-            prepr.append("(%s)" % ", ".join([repr(a) for a in args] +
-                                            ["%s=%s" % (kwarg_fmt(k), bbrepr(v))
-                                             for k, v in kwargs.items()]))
+            prepr.append(format_invocation(args=args, kwargs=kwargs, repr=bbrepr))
         elif op == 'P':
             return _format_path(path)
         i += 2

--- a/glom/core.py
+++ b/glom/core.py
@@ -1975,7 +1975,7 @@ class Fill(object):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        rpr = '' if self.spec is None else repr(self.spec)
+        rpr = '' if self.spec is None else bbrepr(self.spec)
         return '%s(%s)' % (cn, rpr)
 
 

--- a/glom/core.py
+++ b/glom/core.py
@@ -248,6 +248,28 @@ class UnregisteredTarget(GlomError):
         return msg
 
 
+if getattr(__builtins__, '__dict__', None):
+    # pypy's __builtins__ is a module, as is CPython's REPL, but at
+    # normal execution time it's a dict?
+    __builtins__ = __builtins__.__dict__
+    tmpl = '__builtins__.%s'
+else:
+    tmpl = "__builtins__['%s']"
+
+
+_BUILTIN_ID_NAME_MAP = dict([(id(v), tmpl % k)
+                             for k, v in __builtins__.items()])
+
+def _bbrepr(obj):
+    """A better repr for builtins, when the built-in repr isn't
+    roundtrippable.
+    """
+    ret = repr(obj)
+    if not ret.startswith('<'):
+        return ret
+    return _BUILTIN_ID_NAME_MAP.get(id(obj), ret)
+
+
 class Path(object):
     """Path objects specify explicit paths when the default
     ``'a.b.c'``-style general access syntax won't work or isn't

--- a/glom/core.py
+++ b/glom/core.py
@@ -252,12 +252,9 @@ if getattr(__builtins__, '__dict__', None):
     # pypy's __builtins__ is a module, as is CPython's REPL, but at
     # normal execution time it's a dict?
     __builtins__ = __builtins__.__dict__
-    tmpl = '__builtins__.%s'
-else:
-    tmpl = "__builtins__['%s']"
 
 
-_BUILTIN_ID_NAME_MAP = dict([(id(v), tmpl % k)
+_BUILTIN_ID_NAME_MAP = dict([(id(v), k)
                              for k, v in __builtins__.items()])
 
 def _bbrepr(obj):

--- a/glom/core.py
+++ b/glom/core.py
@@ -1444,7 +1444,7 @@ class Check(object):
     def __repr__(self):
         cn = self.__class__.__name__
         posargs = (self.spec,) if self.spec is not T else ()
-        return format_invocation(cn, posargs, self._orig_kwargs)
+        return format_invocation(cn, posargs, self._orig_kwargs, repr=bbrepr)
 
 
 class Auto(object):

--- a/glom/mutation.py
+++ b/glom/mutation.py
@@ -5,7 +5,7 @@ import operator
 from pprint import pprint
 
 from .core import Path, T, S, Spec, glom, UnregisteredTarget, GlomError, PathAccessError, UP
-from .core import TType, register_op, TargetRegistry, _bbrepr
+from .core import TType, register_op, TargetRegistry, bbrepr
 
 try:
     basestring
@@ -13,7 +13,7 @@ except NameError:
     basestring = str
 
 
-if getattr(__builtins__, '__dict__', None):
+if getattr(__builtins__, '__dict__', None) is not None:
     # pypy's __builtins__ is a module, as is CPython's REPL, but at
     # normal execution time it's a dict?
     __builtins__ = __builtins__.__dict__
@@ -189,7 +189,7 @@ class Assign(object):
         cn = self.__class__.__name__
         if self.missing is None:
             return '%s(%r, %r)' % (cn, self._orig_path, self.val)
-        return '%s(%r, %r, missing=%s)' % (cn, self._orig_path, self.val, _bbrepr(self.missing))
+        return '%s(%r, %r, missing=%s)' % (cn, self._orig_path, self.val, bbrepr(self.missing))
 
 
 def assign(obj, path, val, missing=None):

--- a/glom/mutation.py
+++ b/glom/mutation.py
@@ -5,7 +5,7 @@ import operator
 from pprint import pprint
 
 from .core import Path, T, S, Spec, glom, UnregisteredTarget, GlomError, PathAccessError, UP
-from .core import TType, register_op, TargetRegistry
+from .core import TType, register_op, TargetRegistry, _bbrepr
 
 try:
     basestring
@@ -189,7 +189,7 @@ class Assign(object):
         cn = self.__class__.__name__
         if self.missing is None:
             return '%s(%r, %r)' % (cn, self._orig_path, self.val)
-        return '%s(%r, %r, missing=%r)' % (cn, self._orig_path, self.val, self.missing)
+        return '%s(%r, %r, missing=%s)' % (cn, self._orig_path, self.val, _bbrepr(self.missing))
 
 
 def assign(obj, path, val, missing=None):

--- a/glom/reduction.py
+++ b/glom/reduction.py
@@ -5,7 +5,7 @@ from pprint import pprint
 
 from boltons.typeutils import make_sentinel
 
-from .core import TargetRegistry, Path, T, glom, GlomError, UnregisteredTarget
+from .core import TargetRegistry, Path, T, glom, GlomError, UnregisteredTarget, format_invocation, bbrepr
 
 _MISSING = make_sentinel('_MISSING')
 
@@ -96,7 +96,8 @@ class Fold(object):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        return '%s(%r, init=%r, op=%r)' % (cn, self.subspec, self.init, self.op)
+        kwargs = {'init': self.init, 'op': self.op}
+        return format_invocation(cn, (self.subspec,), kwargs, repr=bbrepr)
 
 
 class Sum(Fold):
@@ -122,7 +123,7 @@ class Sum(Fold):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        return '%s(%r, init=%r)' % (cn, self.subspec, self.init)
+        return format_invocation(cn, (self.subspec,), {'init': self.init}, repr=bbrepr)
 
 
 class Flatten(Fold):
@@ -153,9 +154,8 @@ class Flatten(Fold):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        if self.lazy:
-            return '%s(%r, init="lazy")' % (cn, self.subspec)
-        return '%s(%r, init=%r)' % (cn, self.subspec, self.init)
+        kwargs = {'init': 'lazy' if self.lazy else self.init}
+        return format_invocation(cn, (self.subspec,), kwargs, repr=bbrepr)
 
 
 def flatten(target, **kwargs):

--- a/glom/reduction.py
+++ b/glom/reduction.py
@@ -96,7 +96,9 @@ class Fold(object):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        kwargs = {'init': self.init, 'op': self.op}
+        kwargs = {'init': self.init}
+        if self.op is not operator.iadd:
+            kwargs['op'] = self.op
         return format_invocation(cn, (self.subspec,), kwargs, repr=bbrepr)
 
 
@@ -123,7 +125,9 @@ class Sum(Fold):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        return format_invocation(cn, (self.subspec,), {'init': self.init}, repr=bbrepr)
+        args = () if self.subspec is T else (self.subspec,)
+        kwargs = {'init': self.init} if self.init is not int else {}
+        return format_invocation(cn, args, kwargs, repr=bbrepr)
 
 
 class Flatten(Fold):
@@ -154,8 +158,13 @@ class Flatten(Fold):
 
     def __repr__(self):
         cn = self.__class__.__name__
-        kwargs = {'init': 'lazy' if self.lazy else self.init}
-        return format_invocation(cn, (self.subspec,), kwargs, repr=bbrepr)
+        args = () if self.subspec is T else (self.subspec,)
+        kwargs = {}
+        if self.lazy:
+            kwargs['init'] = 'lazy'
+        elif self.init is not list:
+            kwargs['init'] = self.init
+        return format_invocation(cn, args, kwargs, repr=bbrepr)
 
 
 def flatten(target, **kwargs):

--- a/glom/streaming.py
+++ b/glom/streaming.py
@@ -18,7 +18,7 @@ except ImportError:
 from boltons.iterutils import split_iter, chunked_iter, windowed_iter, unique_iter, first
 from boltons.funcutils import FunctionBuilder
 
-from .core import glom, T, STOP, SKIP, Check, _MISSING, Path, TargetRegistry, Call, Spec, S
+from .core import glom, T, STOP, SKIP, Check, _MISSING, Path, TargetRegistry, Call, Spec, S, bbrepr, format_invocation
 
 
 class Iter(object):
@@ -62,29 +62,21 @@ class Iter(object):
         return
 
     def __repr__(self):
-        chunks = [self.__class__.__name__]
+        base_args = ()
         if self.subspec != T:
-            chunks.append('({!r})'.format(self.subspec))
-        else:
-            chunks.append('()')
+            base_args = (self.subspec,)
+        base = format_invocation(self.__class__.__name__, base_args, repr=bbrepr)
+        chunks = [base]
         for fname, args, _ in reversed(self._iter_stack):
             meth = getattr(self, fname)
             fb = FunctionBuilder.from_func(meth)
             fb.args = fb.args[1:]  # drop self
             arg_names = fb.get_arg_names()
             # TODO: something fancier with defaults:
-            chunks.append("." + fname)
-            if len(args) == 0:
-                chunks.append("()")
-            elif len(arg_names) == 1:
-                assert len(args) == 1
-                chunks.append('({!r})'.format(args[0]))
-            elif arg_names:
-                chunks.append('({})'.format(", ".join([
-                    '{}={!r}'.format(name, val) for name, val in zip(arg_names, args)])))
-            else:
-                # p much just slice bc no kwargs
-                chunks.append('({})'.format(", ".join(['%s' % a for a in args])))
+            kwargs = []
+            if len(args) > 1 and arg_names:
+                args, kwargs = (), zip(arg_names, args)
+            chunks.append('.' + format_invocation(fname, args, kwargs, repr=bbrepr))
         return ''.join(chunks)
 
     def glomit(self, target, scope):
@@ -386,5 +378,5 @@ class First(object):
     def __repr__(self):
         cn = self.__class__.__name__
         if self._default is None:
-            return '%s(%r)' % (cn, self._spec)
-        return '%s(%r, default=%r)' % (cn, self._spec, self._default)
+            return '%s(%s)' % (cn, bbrepr(self._spec))
+        return '%s(%s, default=%s)' % (cn, bbrepr(self._spec), bbrepr(self._default))

--- a/glom/test/test_basic.py
+++ b/glom/test/test_basic.py
@@ -229,6 +229,9 @@ def test_invoke():
         ).constants(3, b='b').specs(c='c'
         ).star(args='args2', kwargs='kwargs')
     repr(spec)  # no exceptions
+    assert repr(Invoke(len).specs(T)) == 'Invoke(len).specs(T)'
+    assert (repr(Invoke.specfunc(next).constants(len).constants(1))
+            == 'Invoke.specfunc(next).constants(len).constants(1)')
     assert glom(data, spec) == 'test'
     assert args == [
         (1, 2, 3, 4, 5),

--- a/glom/test/test_basic.py
+++ b/glom/test/test_basic.py
@@ -179,8 +179,10 @@ def test_abstract_iterable():
     class MyIterable(object):
         def __iter__(self):
             return iter([1, 2, 3])
+    mi = MyIterable()
+    assert list(mi) == [1, 2, 3]
 
-    assert isinstance(MyIterable(), glom_core._AbstractIterable)
+    assert isinstance(mi, glom_core._AbstractIterable)
 
 
 def test_call_and_target():
@@ -420,6 +422,6 @@ def test_api_repr():
         if not callable(getattr(v, 'glomit', None)):
             continue
         if v.__repr__ is object.__repr__:
-            spec_types_wo_reprs.append(k)
+            spec_types_wo_reprs.append(k)  # pragma: no cover
 
     assert set(spec_types_wo_reprs) == set([])

--- a/glom/test/test_check.py
+++ b/glom/test/test_check.py
@@ -24,6 +24,8 @@ def test_check_basic():
     assert repr(Check()) == 'Check()'
     assert repr(Check(T.a)) == 'Check(T.a)'
     assert repr(Check(equal_to=1)) == 'Check(equal_to=1)'
+    assert repr(Check(instance_of=dict)) == 'Check(instance_of=dict)'
+    assert repr(Check(T(len), validate=sum)) == 'Check(T(len), validate=sum)'
 
     target = [1, 'a']
     assert glom(target, [Check(type=str, default=SKIP)]) == ['a']

--- a/glom/test/test_fill.py
+++ b/glom/test/test_fill.py
@@ -16,3 +16,5 @@ def test():
 
     assert repr(Fill()) == 'Fill()'
     assert repr(Fill(T)) == 'Fill(T)'
+
+    assert repr(Fill(len)) == 'Fill(len)'

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -31,7 +31,7 @@ def test_assign():
 
     assert repr(Assign(T.a, 1)) == 'Assign(T.a, 1)'
     assign_spec = Assign(T.a, 1, missing=dict)
-    # assert repr(assign_spec) == "Assign(T.a, 1, missing=__builtins__['dict'])"
+    assert repr(assign_spec) == "Assign(T.a, 1, missing=dict)"
     assert repr(assign_spec) == repr(eval(repr(assign_spec)))
 
 

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -30,7 +30,9 @@ def test_assign():
         Assign(T, 1)
 
     assert repr(Assign(T.a, 1)) == 'Assign(T.a, 1)'
-    assert repr(Assign(T.a, 1, missing=dict)).startswith('Assign(T.a, 1, missing=<')
+    assign_spec = Assign(T.a, 1, missing=dict)
+    # assert repr(assign_spec) == "Assign(T.a, 1, missing=__builtins__['dict'])"
+    assert repr(assign_spec) == repr(eval(repr(assign_spec)))
 
 
 def test_assign_spec_val():

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -45,6 +45,10 @@ def test_path_t_roundtrip():
     # check that multiple nested paths reduce
     assert repr(Path(Path(Path('a')))) == "Path('a')"
 
+    # check builtin repr
+    assert repr(T[len]) == 'T[len]'
+    assert repr(T.func(len, sum)) == 'T.func(len, sum)'
+
 
 def test_path_access_error_message():
 

--- a/glom/test/test_reduction.py
+++ b/glom/test/test_reduction.py
@@ -48,7 +48,7 @@ def test_fold():
 
     assert glom(target, Fold(T, lambda: 1, op=lambda l, r: l * r)) == 24
 
-    repr(Fold(T, int))
+    assert repr(Fold(T, int)).startswith('Fold(T, init=int')
 
     # signature coverage
     with pytest.raises(TypeError):

--- a/glom/test/test_reduction.py
+++ b/glom/test/test_reduction.py
@@ -1,4 +1,6 @@
 
+import operator
+
 import pytest
 from boltons.dictutils import OMD
 
@@ -22,7 +24,8 @@ def test_sum_integers():
     target = target + [{}]  # add a non-compliant dict
     assert glom(target, Sum([Coalesce('num', default=0)])) ==4
 
-    repr(Sum())
+    assert repr(Sum()) == 'Sum()'
+    assert repr(Sum(len, init=float)) == 'Sum(len, init=float)'
 
 
 def test_sum_seqs():
@@ -48,7 +51,8 @@ def test_fold():
 
     assert glom(target, Fold(T, lambda: 1, op=lambda l, r: l * r)) == 24
 
-    assert repr(Fold(T, int)).startswith('Fold(T, init=int')
+    assert repr(Fold(T, int)) == 'Fold(T, init=int)'
+    assert repr(Fold(T, int, op=operator.imul)).startswith('Fold(T, init=int, op=<')
 
     # signature coverage
     with pytest.raises(TypeError):
@@ -82,8 +86,9 @@ def test_flatten():
     assert next(gen) == 1
     assert list(gen) == [2, 3]
 
-    repr(Flatten())
-    repr(Flatten(init='lazy'))
+    assert repr(Flatten()) == 'Flatten()'
+    assert repr(Flatten(init='lazy')) == "Flatten(init='lazy')"
+    assert repr(Flatten(init=tuple)) == "Flatten(init=tuple)"
 
 
 def test_flatten_func():

--- a/glom/test/test_streaming.py
+++ b/glom/test/test_streaming.py
@@ -51,7 +51,8 @@ def test_filter():
     out = glom(imags, spec)
     assert out == [0j, 2j]
 
-    assert repr(Iter().filter(T.a.b)).startswith('Iter().filter(T.a.b)')
+    assert repr(Iter().filter(T.a.b)) == 'Iter().filter(T.a.b)'
+    assert repr(Iter(list).filter(sum)) == 'Iter(list).filter(sum)'
 
 
 def test_map():

--- a/glom/test/test_streaming.py
+++ b/glom/test/test_streaming.py
@@ -59,7 +59,7 @@ def test_map():
     spec = Iter().map(lambda x: x * 2)
     out = glom(RANGE_5, spec)
     assert list(out) == [0, 2, 4, 6, 8]
-    assert repr(Iter().map(T.a.b)).startswith('Iter().map(T.a.b)')
+    assert repr(Iter().map(T.a.b)) == 'Iter().map(T.a.b)'
 
 
 def test_split_flatten():

--- a/glom/test/test_target_types.py
+++ b/glom/test/test_target_types.py
@@ -68,13 +68,10 @@ def test_types_bare():
 
     # check again that registering object for 'get' doesn't change the
     # fact that we don't have iterate support yet
-    try:
+    with pytest.raises(UnregisteredTarget) as exc_info:
         glommer.glom({'test': [{'hi': 'hi'}]}, ('test', ['hi']))
-    except UnregisteredTarget as ute:
-        # feel free to update the "(at ['test'])" part to improve path display
-        assert str(ute) == "target type 'list' not registered for 'iterate', expected one of registered types: (dict) (at ['test'])"
-    else:
-        assert False, 'expected an UnregisteredTarget exception'
+    # feel free to update the "(at ['test'])" part to improve path display
+    assert str(exc_info.value) == "target type 'list' not registered for 'iterate', expected one of registered types: (dict) (at ['test'])"
     return
 
 
@@ -98,7 +95,7 @@ def test_exact_register():
     assert value == expected
 
     with pytest.raises(UnregisteredTarget):
-        glommer.glom(list(range(3)), [lambda x: x * 2])
+        glommer.glom(list(range(3)), ['unused'])
 
     return
 
@@ -199,7 +196,7 @@ def test_faulty_op_registration():
     treg = TargetRegistry()
 
     with pytest.raises(TypeError, match="text name, not:"):
-        treg.register_op(None, lambda t: False)
+        treg.register_op(None, len)
     with pytest.raises(TypeError, match="callable, not:"):
         treg.register_op('fake_op', object())
 

--- a/glom/test/test_tutorial.py
+++ b/glom/test/test_tutorial.py
@@ -16,3 +16,5 @@ def test_tutorial():
     assert res == val
 
     contact = Contact('Julian', emails=[Email('julian@sunnyvaletrailerpark.info')])
+    contact.save()
+    assert Contact.objects.get(contact_id=contact.id) is contact


### PR DESCRIPTION
glom deals with a lot of callables, and the `repr` of builtin callables like `dict` and `sum` roundtrip poorly. this is an attempt at making and adopting a small cross-platform utility for the benefit of all the glom specifier types that deal with callables.