### PR TITLE
Fix argument in Fold error message

### DIFF
--- a/glom/reduction.py
+++ b/glom/reduction.py
@@ -64,7 +64,7 @@ class Fold(object):
                             (self.__class__.__name__, op))
         if not callable(init):
             raise TypeError('expected callable for %s init param, not: %r' %
-                            (self.__class__.__name__, op))
+                            (self.__class__.__name__, init))
 
     def glomit(self, target, scope):
         is_agg = False


### PR DESCRIPTION
I encountered this when attempting to pass an instance instead of a callable.

Also: thanks for glom! I'm having fun putting it to use.