### PR TITLE
S()-based scope assignment

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -160,19 +160,26 @@ supported.
    :doc:`the custom spec doc<custom_spec_types>` to learn about more
    advanced, reserved cases.
 
-Updating the scope - ``Let`` & ``A``
+Updating the scope - ``S()`` & ``A``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 glom's scope isn't only set once when the top-level :func:`glom`
 function is called. It's dynamic and updatable.
 
 If your use case requires saving a value from one part of the target
-for usage elsewhere, then :class:`Let` will allow you to save values
-to the scope.
+for usage elsewhere, then **S** will allow you to save values
+to the scope::
 
-.. autoclass:: glom.Let
+    >>> target = {'data': {'val': 9}}
+    >>> spec = (S(value=T['data']['val']), {'val': S['value']})
+    >>> glom(target, spec)
+    {'val': 9}
 
-When only the target is being assigned, you can use the **A**
+Any keyword arguments to the **S** will have their values evaluated as
+a spec, with the result being saved to the keyword argument name in
+the scope.
+
+When only the target is being assigned, you can use the **A** as a
 shortcut::
 
     >>> target = {'data': {'val': 9}}

--- a/glom/__init__.py
+++ b/glom/__init__.py
@@ -15,11 +15,10 @@ from glom.core import (glom,
                        ROOT,
                        MODE,
                        Path,
-                       Let,
                        Vars,
                        Val,
-                       Literal,  # backwards compat
-                       Let,
+                       Literal,  # backwards compat 2020-07
+                       Let,  # backwards compat 2020-07
                        Coalesce,
                        Inspect,
                        GlomError,

--- a/glom/core.py
+++ b/glom/core.py
@@ -1640,7 +1640,7 @@ class ScopeVars(object):
 
 class Vars(object):
     """
-    :class:`Vars` is a helper that can be used with :class:`Let` in order to
+    :class:`Vars` is a helper that can be used with **S** in order to
     store shared mutable state.
 
     Takes the same arguments as :class:`dict()`.
@@ -1667,12 +1667,13 @@ class Vars(object):
 
 class Let(object):
     """
-    This specifier type assigns variables to the scope.
+    Deprecated, kept for backwards compat. Use S(x='y') instead.
 
     >>> target = {'data': {'val': 9}}
     >>> spec = (Let(value=T['data']['val']), {'val': S['value']})
     >>> glom(target, spec)
     {'val': 9}
+
     """
     def __init__(self, **kw):
         if not kw:

--- a/glom/core.py
+++ b/glom/core.py
@@ -1336,6 +1336,12 @@ class TType(object):
         return _t_child(self, '[', item)
 
     def __call__(self, *args, **kwargs):
+        if self is S:
+            if args:
+                raise TypeError('S() takes no positional arguments, got: %r' % (args,))
+            if not kwargs:
+                raise TypeError('S() expected at least one kwarg, got none')
+            # TODO: typecheck kwarg vals?
         return _t_child(self, '(', (args, kwargs))
 
     def __(self, name):
@@ -1425,6 +1431,11 @@ def _t_eval(target, _t, scope):
                 pae = PathAccessError(e, _t, i // 2)
         elif op == '(':
             args, kwargs = arg
+            if cur is scope:
+                scope.update({
+                    k: scope[glom](target, v, scope) for k, v in kwargs.items()})
+                return target
+
             scope[Path] += t_path[2:i+2:2]
             cur = scope[glom](
                 target, Call(cur, args, kwargs), scope)

--- a/glom/core.py
+++ b/glom/core.py
@@ -1405,6 +1405,13 @@ def _t_eval(target, _t, scope):
         if fetch_till > 1 and t_path[1] in ('.', 'P'):
             cur = _s_first_magic(cur, t_path[2], _t)
             i += 2
+        elif root is S and fetch_till > 1 and t_path[1] == '(':
+            # S(var='spec') style assignment
+            _, kwargs = t_path[2]
+            scope.update({
+                k: scope[glom](target, v, scope) for k, v in kwargs.items()})
+            return target
+
     else:
         raise ValueError('TType instance with invalid root')  # pragma: no cover
     pae = None
@@ -1431,11 +1438,6 @@ def _t_eval(target, _t, scope):
                 pae = PathAccessError(e, _t, i // 2)
         elif op == '(':
             args, kwargs = arg
-            if cur is scope:
-                scope.update({
-                    k: scope[glom](target, v, scope) for k, v in kwargs.items()})
-                return target
-
             scope[Path] += t_path[2:i+2:2]
             cur = scope[glom](
                 target, Call(cur, args, kwargs), scope)

--- a/glom/test/test_basic.py
+++ b/glom/test/test_basic.py
@@ -5,13 +5,13 @@ from xml.etree import cElementTree as ElementTree
 import pytest
 
 from glom import glom, SKIP, STOP, Path, Inspect, Coalesce, CoalesceError, Val, Call, T, S, Invoke, Spec, Ref
-from glom import Auto, Fill, Iter, Let, A, Vars, Val, Literal, GlomError
+from glom import Auto, Fill, Iter, A, Vars, Val, Literal, GlomError
 
 import glom.core as glom_core
-from glom.core import UP, ROOT, Let, bbformat, bbrepr
+from glom.core import UP, ROOT, bbformat, bbrepr
 from glom.mutation import PathAssignError
 
-from glom import OMIT  # backwards compat
+from glom import OMIT, Let, Literal  # backwards compat
 
 
 def test_initial_integration():

--- a/glom/test/test_let_vars.py
+++ b/glom/test/test_let_vars.py
@@ -74,3 +74,14 @@ def test_max_skip():
                  S.max)
     result = glom(target, max_spec)
     assert result.max == 9
+
+
+def test_s_scope_assign():
+    spec = (S(a='x'), S.a)
+    assert glom({'x': 'y'}, spec) == 'y'
+
+    with pytest.raises(TypeError):
+        S()
+    with pytest.raises(TypeError):
+        S('nope')
+    return

--- a/glom/test/test_let_vars.py
+++ b/glom/test/test_let_vars.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-from glom import glom, Path, T, S, Val, Let, A, Vars, Val, GlomError, M, Or, SKIP, Coalesce
+from glom import glom, Path, S, A, T, Vars, Val, GlomError, M, SKIP
 
 from glom.core import ROOT
 from glom.mutation import PathAssignError
@@ -9,27 +9,27 @@ from glom.mutation import PathAssignError
 def test_let():
     data = {'a': 1, 'b': [{'c': 2}, {'c': 3}]}
     output = [{'a': 1, 'c': 2}, {'a': 1, 'c': 3}]
-    assert glom(data, (Let(a='a'), ('b', [{'a': S['a'], 'c': 'c'}]))) == output
+    assert glom(data, (S(a='a'), ('b', [{'a': S['a'], 'c': 'c'}]))) == output
     assert glom(data, ('b', [{'a': S[ROOT][Val(T)]['a'], 'c': 'c'}])) == output
 
     with pytest.raises(TypeError):
-        Let('posarg')
+        S('posarg')
     with pytest.raises(TypeError):
-        Let()
+        S()
 
-    assert glom([[1]], (Let(v=Vars()), [[A.v.a]], S.v.a)) == 1
-    assert glom(1, (Let(v=lambda t: {}), A.v['a'], S.v['a'])) == 1
+    assert glom([[1]], (S(v=Vars()), [[A.v.a]], S.v.a)) == 1
+    assert glom(1, (S(v=lambda t: {}), A.v['a'], S.v['a'])) == 1
     with pytest.raises(GlomError):
-        glom(1, (Let(v=lambda t: 1), A.v.a))
+        glom(1, (S(v=lambda t: 1), A.v.a))
 
     class FailAssign(object):
         def __setattr__(self, name, val):
             raise Exception('nope')
 
     with pytest.raises(PathAssignError):
-        glom(1, (Let(v=lambda t: FailAssign()), Path(A.v, 'a')))
+        glom(1, (S(v=lambda t: FailAssign()), Path(A.v, 'a')))
 
-    assert repr(Let(a=T.a.b)) == 'Let(a=T.a.b)'
+    assert repr(S(a=T.a.b)) == 'S(a=T.a.b)'
 
 
 def test_globals():
@@ -42,14 +42,14 @@ def test_vars():
     # check that tuple vars don't "leak" into parent tuple
     assert glom(1, (A.t, Val(2), A.t, S.t)) == 2
     assert glom(1, (A.t, (Val(2), A.t), S.t)) == 1
-    let = Let(v=Vars({'b': 2}, c=3))
+    let = S(v=Vars({'b': 2}, c=3))
     assert glom(1, (let, A.v.a, S.v.a)) == 1
     with pytest.raises(AttributeError):
         glom(1, (let, S.v.a))  # check that Vars() inside a spec doesn't hold state
     assert glom(1, (let, Path(A, 'v', 'a'), S.v.a)) == 1
     assert glom(1, (let, S.v.b)) == 2
     assert glom(1, (let, S.v.c)) == 3
-    assert repr(let) == "Let(v=Vars({'b': 2}, c=3))"
+    assert repr(let) == "S(v=Vars({'b': 2}, c=3))"
     assert repr(Vars(a=1, b=2)) in (
         "Vars(a=1, b=2)", "Vars(b=2, a=1)")
     assert repr(Vars(a=1, b=2).glomit(None, None)) in (
@@ -69,7 +69,7 @@ def test_scoped_vars():
 def test_max_skip():
     target = list(range(10)) + list(range(5))
 
-    max_spec = (Let(max=Vars(max=0)),
+    max_spec = (S(max=Vars(max=0)),
                 [((M > M(S.max.max)) & A.max.max) | Val(SKIP)],
                  S.max)
     result = glom(target, max_spec)
@@ -79,6 +79,8 @@ def test_max_skip():
 def test_s_scope_assign():
     spec = (S(a='x'), S.a)
     assert glom({'x': 'y'}, spec) == 'y'
+
+    assert repr(S(a=T)) == 'S(a=T)'
 
     with pytest.raises(TypeError):
         S()

--- a/glom/test/test_match.py
+++ b/glom/test/test_match.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from glom import glom, S, Val, T, A, Merge, Fill, Let, Ref, Coalesce, STOP, Switch, GlomError
+from glom import glom, S, Val, T, A, Fill, Ref, Coalesce, STOP, Switch
 from glom.matching import (
     Match, M, MatchError, TypeMatchError, And, Or, Not,
     Optional, Required, Regex)
@@ -208,8 +208,8 @@ def test_pattern_matching():
         lambda t: t + 1, Ref('fact', (
             lambda t: t - 1,
             (M == 0) & Fill(1) |
-            (Let(r=Ref('fact')),
-                S, lambda s: s['r'] * s[T]))))
+            (S(r=Ref('fact')),
+             S, lambda s: s['r'] * s[T]))))
 
     assert glom(4, factorial) == 4 * 3 * 2
 
@@ -500,7 +500,7 @@ def test_switch():
     	Switch({})
     with pytest.raises(TypeError):
     	Switch("wrong type")
-    assert glom(None, Switch({Let(a=lambda t: 1): S['a']})) == 1
+    assert glom(None, Switch({S(a=lambda t: 1): S['a']})) == 1
     repr(Switch(cases))
 
 

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -2,7 +2,7 @@ import pytest
 
 from glom import glom, Path, T, S, Spec, Glommer, PathAssignError, PathAccessError
 from glom import assign, Assign, delete, Delete, PathDeleteError
-from glom.core import UnregisteredTarget, Let
+from glom.core import UnregisteredTarget
 
 
 def test_assign():
@@ -229,9 +229,9 @@ def test_delete():
     assert repr(Delete(T.a)) == 'Delete(T.a)'
 
     # test delete from scope
-    assert glom(1, (Let(x=T), S['x'])) == 1
+    assert glom(1, (S(x=T), S['x'])) == 1
     with pytest.raises(PathAccessError):
-        glom(1, (Let(x=T), Delete(S['x']), S['x']))
+        glom(1, (S(x=T), Delete(S['x']), S['x']))
 
     # test raising on missing parent
     with pytest.raises(PathAccessError):

--- a/glom/test/test_scope_vars.py
+++ b/glom/test/test_scope_vars.py
@@ -1,12 +1,12 @@
 
 import pytest
 
-from glom import glom, Path, S, A, T, Vars, Val, GlomError, M, SKIP
+from glom import glom, Path, S, A, T, Vars, Val, GlomError, M, SKIP, Let
 
 from glom.core import ROOT
 from glom.mutation import PathAssignError
 
-def test_let():
+def test_s_scope_assign():
     data = {'a': 1, 'b': [{'c': 2}, {'c': 3}]}
     output = [{'a': 1, 'c': 2}, {'a': 1, 'c': 3}]
     assert glom(data, (S(a='a'), ('b', [{'a': S['a'], 'c': 'c'}]))) == output
@@ -30,6 +30,11 @@ def test_let():
         glom(1, (S(v=lambda t: FailAssign()), Path(A.v, 'a')))
 
     assert repr(S(a=T.a.b)) == 'S(a=T.a.b)'
+
+    spec = (S(a='x'), S.a)
+    assert glom({'x': 'y'}, spec) == 'y'
+
+    return
 
 
 def test_globals():
@@ -77,13 +82,30 @@ def test_max_skip():
 
 
 def test_s_scope_assign():
-    spec = (S(a='x'), S.a)
-    assert glom({'x': 'y'}, spec) == 'y'
-
-    assert repr(S(a=T)) == 'S(a=T)'
-
-    with pytest.raises(TypeError):
-        S()
-    with pytest.raises(TypeError):
-        S('nope')
     return
+
+
+def test_let():  # backwards compat 2020-07
+    data = {'a': 1, 'b': [{'c': 2}, {'c': 3}]}
+    output = [{'a': 1, 'c': 2}, {'a': 1, 'c': 3}]
+    assert glom(data, (Let(a='a'), ('b', [{'a': S['a'], 'c': 'c'}]))) == output
+    assert glom(data, ('b', [{'a': S[ROOT][Val(T)]['a'], 'c': 'c'}])) == output
+
+    with pytest.raises(TypeError):
+        Let('posarg')
+    with pytest.raises(TypeError):
+        Let()
+
+    assert glom([[1]], (Let(v=Vars()), [[A.v.a]], S.v.a)) == 1
+    assert glom(1, (Let(v=lambda t: {}), A.v['a'], S.v['a'])) == 1
+    with pytest.raises(GlomError):
+        glom(1, (Let(v=lambda t: 1), A.v.a))
+
+    class FailAssign(object):
+        def __setattr__(self, name, val):
+            raise Exception('nope')
+
+    with pytest.raises(PathAssignError):
+        glom(1, (Let(v=lambda t: FailAssign()), Path(A.v, 'a')))
+
+    assert repr(Let(a=T.a.b)) == 'Let(a=T.a.b)'

--- a/glom/test/test_scope_vars.py
+++ b/glom/test/test_scope_vars.py
@@ -81,10 +81,6 @@ def test_max_skip():
     assert result.max == 9
 
 
-def test_s_scope_assign():
-    return
-
-
 def test_let():  # backwards compat 2020-07
     data = {'a': 1, 'b': [{'c': 2}, {'c': 3}]}
     output = [{'a': 1, 'c': 2}, {'a': 1, 'c': 3}]


### PR DESCRIPTION
Per discussion, here's a sketch of what it looks like to assign to the scope using `S(var=spec)`. Personally I like the brevity and symmetry, and not needing another import.

Topics for further discussion:

- [x] Prior to this PR, we allow `S()`, even though it's always scope and will always fail at runtime. A small bug.
- [x] ~Should we accept a dict posarg for non-kwarg update?~
- [x] ~Should we typecheck kwarg values?~
- [x] Is there a better way of doing this than `if cur is scope`?