### PR TITLE
Add minimum required face version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='glom',
           'Documentation': 'https://glom.readthedocs.io/en/latest/',
       },
       packages=['glom', 'glom.test'],
-      install_requires=['boltons>=19.3.0', 'attrs', 'face'],
+      install_requires=['boltons>=19.3.0', 'attrs', 'face>=20.1.0'],
       extras_require={
           'yaml': ['PyYAML'],
       },


### PR DESCRIPTION
Since version 20.7.0 `glom` requires at least version 20.1.0 of `face`,
as that's the version of `face` where `face.helpers.get_wrap_width` got
added. This commit adds the version 20.1.0 of `face` to the required
dependencies in `setup.py`, to avoid incompatbilities with environments
which provide older versions of `face`.