### PR TITLE
WIP: Implicit chaining in lists: Make [x, y,...] same as [(x, y, ...)]

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -1833,7 +1833,7 @@ def _handle_dict(target, spec, scope):
 
 
 def _handle_list(target, spec, scope):
-    subspec = spec[0]
+    subspec = Pipe(*spec)
     iterate = scope[TargetRegistry].get_handler('iterate', target, path=scope[Path])
     try:
         iterator = iterate(target)

--- a/glom/test/test_basic.py
+++ b/glom/test/test_basic.py
@@ -429,6 +429,14 @@ def test_pipe():
     assert repr(Pipe(1, Pipe([2], dict))) == 'Pipe(1, Pipe([2], dict))'
 
 
+def test_list_implicit_chaining():
+    target = [{'outer': {'inner': str(i ** 2)}} for i in range(5)]
+    spec_implicit = ['outer', 'inner', int]
+    spec_explicit = [('outer', 'inner', int)]
+
+    assert glom(target, spec_implicit) == glom(target, spec_explicit) == [0, 1, 4, 9, 16]
+
+
 _IS_PYPY = '__pypy__' in sys.builtin_module_names
 @pytest.mark.skipif(_IS_PYPY, reason='pypy othertype.__repr__ is never object.__repr__')
 def test_api_repr():


### PR DESCRIPTION
Fixes #220

There are currently multiple test failures because of #107. I think this demonstrates that the current handling of `SKIP` is not optimal, since I would definitely expect `glom(target, spec) == glom(target, (spec,))`.