### PR TITLE
Delete setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[wheel]
-universal = 1
-
-[metadata]
-license_file = LICENSE


### PR DESCRIPTION
The wheel is not universal (drops py2 from wheel name) and LICENSE is recognized automatically.