### PR TITLE
Fix invalid escape sequence '\ ' warning

### DIFF
--- a/glom/matching.py
+++ b/glom/matching.py
@@ -762,7 +762,7 @@ def _glom_match(target, spec, scope):
 
 
 class Switch(object):
-    """The :class:`Switch` specifier type routes data processing based on
+    r"""The :class:`Switch` specifier type routes data processing based on
     matching keys, much like the classic switch statement.
 
     Here is a spec which differentiates between lowercase English


### PR DESCRIPTION
I didn't go thru the whole code base, this is just a warning that has been pestering me for a while. :)