### PR TITLE
Add --scalar flag to CLI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE CHANGELOG.md tox.ini requirements.txt requirements-rtd.txt .coveragerc Makefile pytest.ini .tox-coveragerc
-exclude TODO.md codecov.yml .readthedocs.yaml
+exclude TODO.md codecov.yml .readthedocs.yaml requirements.in
 global-exclude flycheck_*
 
 graft glom/test/data

--- a/glom/cli.py
+++ b/glom/cli.py
@@ -43,14 +43,14 @@ from face import (Command,
                   CommandLineError,
                   UsageError)
 from face.utils import isatty
+from boltons.iterutils import is_scalar
 
 import glom
 from glom import Path, GlomError, Inspect
 
-# TODO: --target-format scalar = unquoted if single value, error otherwise, maybe even don't output newline
-# TODO: --default
+# TODO: --default?
 
-def glom_cli(target, spec, indent, debug, inspect):
+def glom_cli(target, spec, indent, debug, inspect, scalar):
     """Command-line interface to the glom library, providing nested data
     access and data restructuring with the power of Python.
     """
@@ -70,7 +70,11 @@ def glom_cli(target, spec, indent, debug, inspect):
 
     if not indent:
         indent = None
-    print(json.dumps(result, indent=indent, sort_keys=True))
+    
+    if scalar and is_scalar(result):
+        print(result, end='')
+    else:
+        print(json.dumps(result, indent=indent, sort_keys=True))
     return
 
 
@@ -86,7 +90,10 @@ def get_command():
 
     cmd.add('--indent', int, missing=2,
             doc='number of spaces to indent the result, 0 to disable pretty-printing')
-
+    
+    cmd.add('--scalar', parse_as=True,
+            doc="if the result is a single value (not a collection), output it"
+            " without quotes or whitespace, for easier usage in scripts")
     cmd.add('--debug', parse_as=True, doc='interactively debug any errors that come up')
     cmd.add('--inspect', parse_as=True, doc='interactively explore the data')
     return cmd

--- a/glom/test/test_cli.py
+++ b/glom/test/test_cli.py
@@ -63,6 +63,14 @@ def test_cli_spec_argv_target_stdin_basic(cc):
     assert res.stdout == BASIC_OUT
 
 
+def test_cli_scalar(cc):
+    res = cc.run(['glom', 'a.b.c', '{"a": {"b": {"c": "d"}}}'])
+    assert res.stdout == '"d"\n'
+
+    res = cc.run(['glom', '--scalar', 'a.b.c', '{"a": {"b": {"c": "d"}}}'])
+    assert res.stdout == 'd'
+
+
 def test_cli_spec_target_files_basic(cc, basic_spec_path, basic_target_path):
     res = cc.run(['glom', '--indent', '0', '--target-file',
                   basic_target_path, '--spec-file', basic_spec_path])


### PR DESCRIPTION
I was using glom in a script this week, specifically to extract single values from API calls. I noticed I kept having to trim the quotes and whitespace off of the JSON output, because even when it's a single value, it's quoted and followed by a newline. 

So this feature strips the quotes and whitespace when passed a new flag: `--scalar`. This is only done when the glom result is not a collection. If it is, it falls back to normal json output.

Some items to consider:

1. Name?
    - I have SQLAlchemy 2.0 on the brain and scalar is everywhere. But also boltons has an `is_scalar` function that maps exactly to this, so even if it's jargon-y, I think it's accurate.
1. Should it be an error if the output is not a single value?
    - I think for my use case the ergonomics would be worse.
1. Right now, output is always json. Would it be better to do `--output "json"|"scalar"`?
    - Kinda don't want to get into the business of emitting yaml, etc.?

None of these are blockers, I am good to merge as is.