### PR TITLE
fix negative-step slicing in Path.__getitem__

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -730,27 +730,21 @@ class Path:
 
     def __getitem__(self, i):
         cur_t_path = self.path_t.__ops__
-        try:
-            step = i.step
-            start = i.start if i.start is not None else 0
-            stop = i.stop
+        if isinstance(i, slice):
+            # slice the (op, arg) pairs directly so that step and
+            # negative-step slices behave like ordinary sequence slicing
+            parts = tuple(zip(cur_t_path[1::2], cur_t_path[2::2]))
+            new_t = TType()
+            new_t.__ops__ = (cur_t_path[0],) + sum(parts[i], ())
+            return Path(new_t)
 
-            start = (start * 2) + 1 if start >= 0 else (start * 2) + len(cur_t_path)
-            if stop is not None:
-                stop = (stop * 2) + 1 if stop >= 0 else (stop * 2) + len(cur_t_path)
-        except AttributeError:
-            step = 1
-            start = (i * 2) + 1 if i >= 0 else (i * 2) + len(cur_t_path)
-            if start < 0 or start >= len(cur_t_path):
-                raise IndexError('Path index %d out of range for Path of length %d' % (i, (len(cur_t_path) - 1) // 2))
-            stop = ((i + 1) * 2) + 1 if i >= 0 else ((i + 1) * 2) + len(cur_t_path)
+        start = (i * 2) + 1 if i >= 0 else (i * 2) + len(cur_t_path)
+        if start < 0 or start >= len(cur_t_path):
+            raise IndexError('Path index %d out of range for Path of length %d' % (i, (len(cur_t_path) - 1) // 2))
+        stop = ((i + 1) * 2) + 1 if i >= 0 else ((i + 1) * 2) + len(cur_t_path)
 
         new_t = TType()
-        new_path = cur_t_path[start:stop]
-        if step is not None and step != 1:
-            new_path = tuple(zip(new_path[::2], new_path[1::2]))[::step]
-            new_path = sum(new_path, ())
-        new_t.__ops__ = (cur_t_path[0],) + new_path
+        new_t.__ops__ = (cur_t_path[0],) + cur_t_path[start:stop]
         return Path(new_t)
 
     def __repr__(self):

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -209,6 +209,11 @@ def test_path_slices():
     # slicing and stepping
     assert path[1::2] == Path(T.b, 2)
 
+    # negative step, like ordinary sequence slicing
+    assert path[::-1] == Path(T(test='yes'), 2, 1, T.b, T.a)
+    assert path[3:1:-1] == Path(2, 1)
+    assert path[-1:-3:-1] == Path(T(test='yes'), 2)
+
 
 def test_path_values():
     path = Path(T.a.b, 1, 2, T(test='yes'))


### PR DESCRIPTION
**Negative-step Path slicing silently returns the wrong parts**
`Path.__getitem__` mapped the slice bounds onto the internal doubled `__ops__` tuple and always took a forward slice, so `path[3:1:-1]`, `path[4::-1]`, and similar came back empty or truncated instead of stepping backward. I reworked the slice branch to slice the (op, arg) pairs directly, which follows normal sequence semantics; the integer-index/out-of-range path from GH-299 is left as-is.