### PR TITLE
Fix Path slicing to match standard sequence semantics

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -730,27 +730,25 @@ class Path:
 
     def __getitem__(self, i):
         cur_t_path = self.path_t.__ops__
-        try:
-            step = i.step
-            start = i.start if i.start is not None else 0
-            stop = i.stop
+        if isinstance(i, slice):
+            # slicing mirrors standard sequence slicing over the path's
+            # components: out-of-range bounds are clamped and negative
+            # steps are honored, exactly as for a list/tuple of the
+            # values returned by .values(). Each component occupies a
+            # (op, value) pair at ops offset (2 * idx) + 1.
+            new_path = ()
+            for idx in range(*i.indices(len(self))):
+                new_path += cur_t_path[(idx * 2) + 1:(idx * 2) + 3]
+            new_t = TType()
+            new_t.__ops__ = (cur_t_path[0],) + new_path
+            return Path(new_t)
 
-            start = (start * 2) + 1 if start >= 0 else (start * 2) + len(cur_t_path)
-            if stop is not None:
-                stop = (stop * 2) + 1 if stop >= 0 else (stop * 2) + len(cur_t_path)
-        except AttributeError:
-            step = 1
-            start = (i * 2) + 1 if i >= 0 else (i * 2) + len(cur_t_path)
-            if start < 0 or start >= len(cur_t_path):
-                raise IndexError('Path index %d out of range for Path of length %d' % (i, (len(cur_t_path) - 1) // 2))
-            stop = ((i + 1) * 2) + 1 if i >= 0 else ((i + 1) * 2) + len(cur_t_path)
+        start = (i * 2) + 1 if i >= 0 else (i * 2) + len(cur_t_path)
+        if start < 0 or start >= len(cur_t_path):
+            raise IndexError('Path index %d out of range for Path of length %d' % (i, (len(cur_t_path) - 1) // 2))
 
         new_t = TType()
-        new_path = cur_t_path[start:stop]
-        if step is not None and step != 1:
-            new_path = tuple(zip(new_path[::2], new_path[1::2]))[::step]
-            new_path = sum(new_path, ())
-        new_t.__ops__ = (cur_t_path[0],) + new_path
+        new_t.__ops__ = (cur_t_path[0],) + cur_t_path[start:start + 2]
         return Path(new_t)
 
     def __repr__(self):

--- a/glom/test/test_path_and_t.py
+++ b/glom/test/test_path_and_t.py
@@ -210,6 +210,45 @@ def test_path_slices():
     assert path[1::2] == Path(T.b, 2)
 
 
+def test_path_slices_match_sequence_semantics():
+    # Path slicing must mirror standard sequence slicing over the
+    # path's components (the values returned by .values()), including
+    # clamping of out-of-range bounds and support for negative steps.
+    path = Path('a', 'b', 'c')
+    vals = path.values()
+    assert vals == ('a', 'b', 'c')
+
+    # out-of-range negative start/stop must be clamped, not wrap to the
+    # end (previously silently returned an empty or truncated Path)
+    assert path[-4:2].values() == vals[-4:2] == ('a', 'b')
+    assert path[-5:].values() == vals[-5:] == ('a', 'b', 'c')
+    assert path[:-5].values() == vals[:-5] == ()
+    assert path[-100:100].values() == vals[-100:100] == ('a', 'b', 'c')
+
+    # negative steps (e.g. reversing a path) must be honored
+    assert path[::-1].values() == vals[::-1] == ('c', 'b', 'a')
+    assert path[2::-1].values() == vals[2::-1] == ('c', 'b', 'a')
+    assert path[::-2].values() == vals[::-2] == ('c', 'a')
+
+    # a slice that yields nothing must produce a valid, empty Path
+    # (previously produced a corrupt Path with misaligned op/value ops)
+    empty = Path('x', 'y')[-4:-3]
+    assert empty == Path()
+    assert empty.values() == ()
+
+    # exhaustive cross-check against tuple slicing for a range of bounds
+    # and steps, over paths of several lengths
+    for n in range(5):
+        p = Path(*['k%d' % i for i in range(n)])
+        pv = p.values()
+        bounds = [None] + list(range(-n - 2, n + 3))
+        for start in bounds:
+            for stop in bounds:
+                for step in (None, 1, 2, 3, -1, -2):
+                    key = slice(start, stop, step)
+                    assert p[key].values() == pv[key], (n, start, stop, step)
+
+
 def test_path_values():
     path = Path(T.a.b, 1, 2, T(test='yes'))
 


### PR DESCRIPTION
### Problem

`Path.__getitem__` handles slicing by scaling the `start`/`stop` indices into
the path's internal `(op, value)` ops layout, but it never clamps out-of-range
bounds and mishandles negative steps. The result is a `Path` whose `.values()`
disagrees with the equivalent tuple slice, and empty slices produce a `Path`
with a misaligned ops tuple:

```python
>>> from glom import Path
>>> p = Path('a', 'b', 'c')
>>> p.values()
('a', 'b', 'c')
>>> p[-5:].values()          # expected ('a', 'b', 'c')
('c',)
>>> p[::-1].values()         # expected ('c', 'b', 'a')
('a', 'b', 'c')
>>> Path('x', 'y')[-4:-3]    # expected Path() ; corrupt result
```

Integer indexing already clamps/raises correctly; only the slice branch is
affected. This is the sibling of the recent integer-index fix (GH-299).

### Fix

Split the slice branch out and drive it with `range(*i.indices(len(self)))`,
which yields exactly the component indices standard sequence slicing would
(clamped bounds, negative steps honored). The `(op, value)` pairs for those
components are then reassembled. The integer-index branch is unchanged.

### Tests

`test_path_slices_match_sequence_semantics` checks clamped negative bounds,
negative steps, empty-slice validity, and an exhaustive cross-check of
`Path(...)[key].values() == values_tuple[key]` over paths of length 0–4 and a
grid of start/stop/step values.

`pytest glom/test/test_path_and_t.py` passes (the 3 unrelated `test_cli.py`
failures in my environment are a missing optional YAML dependency and reproduce
on a clean checkout).
