### PR TITLE
catch KeyError in Delete._del_one so ignore_missing works

### DIFF
--- a/glom/mutation.py
+++ b/glom/mutation.py
@@ -292,7 +292,7 @@ class Delete:
         if op == '[':
             try:
                 del dest[arg]
-            except IndexError as e:
+            except (IndexError, KeyError) as e:
                 if not self.ignore_missing:
                     raise PathDeleteError(e, self.path, arg)
         elif op == '.':

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -316,6 +316,18 @@ def test_delete_ignore_missing():
     assert delete({}, 'a', ignore_missing=True) == {}
     assert delete({}, 'a.b', ignore_missing=True) == {}
 
+    # explicit item access (a '[' op) on a missing dict key raises
+    # KeyError rather than IndexError; ignore_missing should still skip it
+    assert glom({'a': 1}, Delete(T['zzz'], ignore_missing=True)) == {'a': 1}
+    with pytest.raises(PathDeleteError, match='could not delete'):
+        glom({'a': 1}, Delete(T['zzz']))
+
+    # under a broadcast, a missing key partway through must not leave the
+    # earlier elements half-deleted when ignore_missing is set
+    target = {'items': [{'k': 1, 'keep': 'a'}, {'nope': 2}, {'k': 3, 'keep': 'b'}]}
+    glom(target, Delete(Path(T['items'].__star__()['k']), ignore_missing=True))
+    assert target == {'items': [{'keep': 'a'}, {'nope': 2}, {'keep': 'b'}]}
+
 
 def test_star_broadcast():
     val = {'a': [{'b': [{'c': 1}, {'c': 2}, {'c': 3}]}]}


### PR DESCRIPTION
    >>> glom({'a': 1}, Delete(T['zzz'], ignore_missing=True))
    glom.core.GlomError.wrap(KeyError): 'zzz'

`Delete._del_one` guards its item-delete branch with `except IndexError`, but
`del some_dict[missing_key]` raises `KeyError`, so an explicit `T['key']` path
slips past the `ignore_missing` guard. The `.`-op branch already catches
`AttributeError` and the `P`-op branch catches `Exception`; only the `[` branch
is narrow, which is why the string-path form (`Delete('zzz', ignore_missing=True)`)
already works and the bracket form does not.

The bigger issue shows up under a broadcast: the uncaught `KeyError` aborts the
loop midway, leaving the in-place target partially deleted even though
`ignore_missing` was set.

Widening the branch to `(IndexError, KeyError)` lets `ignore_missing` skip
missing dict keys and otherwise raises `PathDeleteError`, matching the other two
branches. The added test covers the scalar case and the broadcast case where the
earlier elements must not be half-deleted.
