### PR TITLE
wrap setitem/setattr assign failures in PathAssignError

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -1662,9 +1662,15 @@ def _t_eval(target, _t, scope):
 def _assign_op(dest, op, arg, val, path, scope):
     """helper method for doing the assignment on a T operation"""
     if op == '[':
-        dest[arg] = val
+        try:
+            dest[arg] = val
+        except Exception as e:
+            raise PathAssignError(e, path, arg)
     elif op == '.':
-        setattr(dest, arg, val)
+        try:
+            setattr(dest, arg, val)
+        except Exception as e:
+            raise PathAssignError(e, path, arg)
     elif op == 'P':
         _assign = scope[TargetRegistry].get_handler('assign', dest)
         try:

--- a/glom/test/test_mutation.py
+++ b/glom/test/test_mutation.py
@@ -100,6 +100,20 @@ def test_sequence_assign():
     return
 
 
+def test_assign_t_form_raises_path_assign_error():
+    # a failing assignment reached through a T-expression destination
+    # (setitem/setattr ops) should raise PathAssignError, just like the
+    # string/Path form already does. Previously these leaked the raw
+    # IndexError/TypeError/AttributeError wrapped as a generic GlomError.
+    with pytest.raises(PathAssignError, match='could not assign'):
+        glom(['short', 'list'], Assign(T[5], 'x'))
+    with pytest.raises(PathAssignError, match='could not assign'):
+        glom(('a', 'b'), Assign(T[0], 'x'))
+    with pytest.raises(PathAssignError, match='could not assign'):
+        glom(5, Assign(T.foo, 1))
+    return
+
+
 def test_invalid_assign_op_target():
     target = {'afunc': lambda x: 'hi %s' % x}
     spec = T['afunc'](x=1)


### PR DESCRIPTION
`_assign_op` only turned failures into `PathAssignError` for the registry ('P') branch, so an assignment through a T-expression destination leaked the raw error instead:
- `Assign(T[i], v)` past the end of a list, or into an immutable tuple, surfaced a bare `IndexError`/`TypeError` wrapped by the generic trace
- `Assign(T.attr, v)` onto a read-only attribute did the same with `AttributeError`
- the string/`Path` form already raised `PathAssignError`, and `Delete._del_one` wraps all three op branches, so this was the odd one out

Wrapped the setitem and setattr branches the same way, which also matches what the `Assign` docstring already promises. Test covers the list, tuple, and attribute cases.