### PR TITLE
chore(ci): upgrade actions to latest and pin to commit SHAs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,8 +30,8 @@ jobs:
           - { name: "3.7", python: "3.7", os: ubuntu-22.04, tox: py37 }
           - { name: "PyPy3", python: "pypy-3.9", os: ubuntu-latest, tox: pypy3 }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -43,7 +43,7 @@ jobs:
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }},coverage-report
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v5"
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           files: ./.tox/coverage.xml


### PR DESCRIPTION
Upgrades all workflow actions to latest releases (removes the Node 20 deprecation warnings) and pins them to full commit SHAs with # vX.Y.Z comments. Same treatment as mahmoud/boltons#427.