### PR TITLE
Fix Coalesce accepting default + default_factory when default is falsy

### DIFF
--- a/glom/core.py
+++ b/glom/core.py
@@ -904,7 +904,7 @@ class Coalesce:
         self._orig_kwargs = dict(kwargs)
         self.default = kwargs.pop('default', _MISSING)
         self.default_factory = kwargs.pop('default_factory', _MISSING)
-        if self.default and self.default_factory:
+        if self.default is not _MISSING and self.default_factory is not _MISSING:
             raise ValueError('expected one of "default" or "default_factory", not both')
         self.skip = kwargs.pop('skip', _MISSING)
         if self.skip is _MISSING:

--- a/glom/test/test_basic.py
+++ b/glom/test/test_basic.py
@@ -82,6 +82,10 @@ def test_coalesce():
     with pytest.raises(ValueError):
         Coalesce('x', 'y', default=1, default_factory=list)
 
+    # a falsy default is still mutually exclusive with default_factory
+    with pytest.raises(ValueError):
+        Coalesce('x', 'y', default=0, default_factory=list)
+
     # check that arbitrary values can be skipped
     assert glom(val, Coalesce('xxx', 'yyy', 'a.b', default='zzz', skip='c')) == 'zzz'
 


### PR DESCRIPTION
### The bug

`Coalesce`'s guard against passing both `default` and `default_factory` uses a truthiness test, so a **falsy** `default` bypasses it:

```python
Coalesce('a', default=5, default_factory=list)   # ValueError (correct)
Coalesce('a', default=0, default_factory=list)   # no error  <- BUG
```

Same silent-accept for `default=''`, `None`, `[]`, `False` — all ordinary default values. When both are accepted, `default_factory` is silently ignored (`default` wins), instead of raising the documented `ValueError`.

### Root cause

`glom/core.py`, `Coalesce.__init__`:

```python
if self.default and self.default_factory:
    raise ValueError('expected one of "default" or "default_factory", not both')
```

Every other `default`/`default_factory` check in the same method uses the `is not _MISSING` sentinel (the `glomit` default logic, the arg parsing); only this guard uses truthiness, so a falsy-but-present `default` reads as "not passed".

### The fix

```python
if self.default is not _MISSING and self.default_factory is not _MISSING:
    raise ValueError('expected one of "default" or "default_factory", not both')
```

### Verification

- After the fix, all falsy `default` values raise `ValueError` when combined with `default_factory`; single-arg `default=0` and `default_factory=list` still work; the truthy-both case still raises.
- The existing `test_coalesce` already asserts this mutual exclusion (`glom/test/test_basic.py`) but only with a truthy `default=1`, which never exercised the bug — I added a `default=0` case. It fails on `master` (`DID NOT RAISE ValueError`) and passes with the fix.
- Full suite: 200 passed (the 2 `test_cli` failures are pre-existing, from PyYAML not being installed — unrelated to this change).

This is an argument-validation fix (it only changes behavior when a caller passes both mutually-exclusive arguments), self-proving against the mutual-exclusion the test already documents.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
