### PR TITLE
fix: replace bare except clauses with except Exception in test files

### DIFF
--- a/glom/test/test_error.py
+++ b/glom/test/test_error.py
@@ -131,7 +131,7 @@ def _make_stack(spec, **kwargs):
             try:
                 print(f' !! failed to stringify {type(value).__name__} object, got {be}')
                 traceback.print_exc()
-            except:
+            except Exception:
                 print(' !! unable to print trace')
             return f'<unprintable {type(value).__name__} object got {be}>'
 

--- a/glom/test/test_snippets.py
+++ b/glom/test/test_snippets.py
@@ -35,7 +35,7 @@ def _find_snippets():
 
 try:
     SNIPPETS = _find_snippets()
-except:
+except Exception:
     SNIPPETS = []  # in case running in an environment without docs
 
 SNIPPETS_GLOBALS = copy.copy(glom.__dict__)


### PR DESCRIPTION
## Summary

Replace two bare `except:` clauses in test files with `except Exception:`.

### Changes

**`glom/test/test_snippets.py` line 38** — fallback when `_find_snippets()` fails in environments without docs:
```python
# Before
except:
    SNIPPETS = []  # in case running in an environment without docs

# After
except Exception:
    SNIPPETS = []  # in case running in an environment without docs
```

**`glom/test/test_error.py` line 134** — fallback when printing an error trace fails:
```python
# Before
except:
    print(' !! unable to print trace')

# After
except Exception:
    print(' !! unable to print trace')
```

### Why

Bare `except:` silently catches `KeyboardInterrupt` and `SystemExit`, which should propagate. All exceptions that `_find_snippets()`, `print()`, or `traceback.print_exc()` can actually raise are subclasses of `Exception`, making `except Exception:` the correct and safer choice.