### PR TITLE
Bound repr recursion depth to avoid RecursionError on cyclic targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The glom team's approach to updates can be summed up as:
 Check this page when upgrading, we strive to keep the updates
 summarized and well-linked.
 
+## Unreleased
+
+- Fix a `RecursionError` when glom formats an error trace for a
+  self-referential target. `bbrepr` no longer raises its recursion-depth
+  limit, so a cyclic structure's repr is bounded and truncated instead of
+  overflowing the stack (see [issue 315][i315]).
+
+[i315]: https://github.com/mahmoud/glom/issues/315
+
 ## 25.12.0
 
 _(December 28, 2025)_

--- a/glom/core.py
+++ b/glom/core.py
@@ -519,6 +519,12 @@ class _BBRepr(Repr):
         for name in self.__dict__:
             if not isinstance(getattr(self, name), int):
                 continue
+            # ...except the recursion-depth limit: raising it defeats the
+            # guard that keeps repr() of a self-referential structure from
+            # exhausting the interpreter stack (see #315). Leave maxlevel at
+            # reprlib's bounded default.
+            if name == 'maxlevel':
+                continue
             setattr(self, name, 1024)
 
     def repr1(self, x, level):

--- a/glom/test/test_error.py
+++ b/glom/test/test_error.py
@@ -555,3 +555,21 @@ glom.core.GlomError.wrap(IndexError): error raised while processing, details bel
  - Spec: []
 IndexError: list index out of range
 """
+
+
+def test_self_referential_target_does_not_recurse():
+    """A self-referential target must not overflow the stack while glom
+    formats an error trace of it. bbrepr keeps a bounded recursion depth so
+    the repr is truncated instead of recursing forever (see #315)."""
+    d = {}
+    d['self'] = d
+
+    # bbrepr of a cyclic structure is bounded and does not raise.
+    r = bbrepr(d)
+    assert r.endswith('}')
+    assert '...' in r
+
+    # A failing glom over a self-referential target surfaces the real
+    # PathAccessError rather than a RecursionError from formatting the trace.
+    with pytest.raises(PathAccessError):
+        glom(d, 'missing')


### PR DESCRIPTION
Fixes #315.

## Problem

`glom()` over a self-referential target raises `RecursionError` instead of surfacing the real access error:

```python
import glom
d = {}
d["self"] = d
glom.glom(d, "missing")
# RecursionError: maximum recursion depth exceeded while getting the repr of an object
```

The recursion is not in the traversal — it is in error formatting. When glom builds the target/spec trace for a failing lookup, it reprs the target with `bbrepr`. A cyclic target should repr to something bounded like `{"self": {"self": ... {...}}}`, but instead it recurses until the interpreter stack is exhausted.

## Root cause

`_BBRepr.__init__` turns *every* integer limit on `reprlib.Repr` up to 1024:

```python
for name in self.__dict__:
    if not isinstance(getattr(self, name), int):
        continue
    setattr(self, name, 1024)
```

That set includes `maxlevel`, which is exactly the recursion-depth guard `reprlib` uses (default `6`) to keep `repr()` of a self-referential structure from recursing forever. With `maxlevel = 1024`, the repr recurses ~1024 frames deep and blows the stack before the guard trips.

## Fix

Skip `maxlevel` when raising the limits, leaving it at `reprlib`s bounded default. The length/size limits (`maxstring`, `maxdict`, `maxlist`, …) stay high, so ordinary reprs are still shown in full; only the recursion depth is kept bounded, so a cyclic structure truncates with `...` instead of overflowing the stack.

After the fix the same call surfaces the real error:

```text
glom.core.PathAccessError: could not access "missing" ...
 - Target: {"self": {"self": {"self": {"self": {"self": {"self": {...}}}}}}}
```

## Test

Adds `test_self_referential_target_does_not_recurse` in `glom/test/test_error.py`: `bbrepr` of a cyclic dict is bounded (ends in `}`, contains `...`), and a failing `glom()` over a self-referential target raises `PathAccessError` rather than `RecursionError`.

## Verification (local, Python 3.11)

- **RED→GREEN**: with the change reverted, the new test fails with `RecursionError`; with the change it passes.
- `pytest glom/test/test_error.py` — 23 passed. Full suite: 201 passed (the 2 pre-existing `test_cli` failures are unrelated — a missing optional YAML dependency in the environment, and fail on `master` without this change too).