### PR TITLE
Bound flatten traversal by actual nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The glom team's approach to updates can be summed up as:
 Check this page when upgrading, we strive to keep the updates
 summarized and well-linked.
 
+## Unreleased
+
+- Make `flatten()` traverse intermediate levels with an explicit iterator stack.
+  Empty targets no longer allocate work proportional to the requested `levels`,
+  and deeply nested inputs do not require recursive generator chains. Lazy
+  consumption and the final accumulator semantics are preserved. (#312)
+
 ## 25.12.0
 
 _(December 28, 2025)_

--- a/glom/reduction.py
+++ b/glom/reduction.py
@@ -186,6 +186,36 @@ class Flatten(Fold):
         return format_invocation(cn, args, kwargs, repr=bbrepr)
 
 
+class _FlattenLevels(Flatten):
+    """Flatten intermediate levels using a stack bounded by actual nesting."""
+
+    def __init__(self, levels, init):
+        super().__init__(init=init)
+        self.levels = levels
+
+    def _fold(self, iterator):
+        def intermediate_items():
+            stack = [(iterator, self.levels - 1)]
+            while stack:
+                current, remaining = stack[-1]
+                try:
+                    value = next(current)
+                except StopIteration:
+                    stack.pop()
+                    continue
+                if remaining:
+                    stack.append((iter(value), remaining - 1))
+                else:
+                    yield value
+
+        return super()._fold(intermediate_items())
+
+    def __repr__(self):
+        init = 'lazy' if self.lazy else self.init
+        return format_invocation(self.__class__.__name__, (),
+                                 {'levels': self.levels, 'init': init}, repr=bbrepr)
+
+
 def flatten(target, **kwargs):
     """At its most basic, ``flatten()`` turns an iterable of iterables
     into a single list. But it has a few arguments which give it more
@@ -199,7 +229,9 @@ def flatten(target, **kwargs):
           or even :class:`int`. You can also pass ``init="lazy"`` to
           get a generator.
        levels (int): A positive integer representing the number of
-          nested levels to flatten. Defaults to 1.
+          nested levels to flatten. Defaults to 1. Intermediate traversal
+          uses space proportional to the actual nesting, not this limit;
+          empty iterables finish without visiting nonexistent levels.
        spec: The glomspec to fetch before flattening. This defaults to the
           the root level of the object.
 
@@ -256,9 +288,8 @@ def flatten(target, **kwargs):
         return target
     if levels < 0:
         raise ValueError('expected levels >= 0, not %r' % levels)
-    spec = (subspec,)
-    spec += (Flatten(init="lazy"),) * (levels - 1)
-    spec += (Flatten(init=init),)
+    levels = operator.index(levels)
+    spec = (subspec, _FlattenLevels(levels, init))
 
     return glom(target, spec)
 

--- a/glom/test/test_reduction.py
+++ b/glom/test/test_reduction.py
@@ -151,3 +151,41 @@ def test_merge_func():
     # basic signature test
     with pytest.raises(TypeError):
         merge([], nonexistentkwarg=False)
+
+
+@pytest.mark.parametrize('target', [[], [[]], [[[]]]])
+@pytest.mark.parametrize('init', [list, dict, 'lazy'])
+def test_flatten_empty_at_large_depth(target, init):
+    # A huge declared depth should not construct a huge tuple or generator chain.
+    result = flatten(target, levels=10 ** 30, init=init)
+    assert (list(result) if init == 'lazy' else result) == ({} if init is dict else [])
+
+
+def test_flatten_deep_nesting_without_recursion():
+    target = [42]
+    for _ in range(2000):
+        target = [target]
+    assert flatten(target, levels=2000) == [42]
+
+
+def test_flatten_levels_preserve_lazy_consumption():
+    consumed = []
+
+    def source():
+        for value in range(3):
+            consumed.append(value)
+            yield [[value]]
+
+    result = flatten(source(), levels=2, init='lazy')
+    assert consumed == []
+    assert next(result) == 0
+    assert consumed == [0]
+    assert list(result) == [1, 2]
+
+
+def test_flatten_levels_preserve_accumulator():
+    assert flatten([[[1, 2]], [[3]]], levels=3, init=int) == 6
+    assert flatten([[['a', 'bc']]], levels=3, init=str) == 'abc'
+    assert flatten({'items': [[[1], [2]]]}, spec='items', levels=2) == [1, 2]
+    with pytest.raises(TypeError):
+        flatten([], levels=2.5)


### PR DESCRIPTION
Fixes #312.

Replace the tuple of one lazy `Flatten` per requested level with an explicit iterator stack. Empty input now finishes without allocating a huge spec or generator chain, and deep inputs avoid recursive generator calls. The final `Flatten` accumulator still handles addition, including `int`, `str`, and lazy output.

Validation: nine empty/nested-empty cases fail before this change and pass afterward; 21 reduction tests pass, including 2,000-level nesting, lazy consumption, subspecs, and accumulator controls. Full tests/doctests: 277 passed, two skipped, and one CLI PATH failure that passes when rerun with the installed command on PATH. Packaging manifest and diff checks pass. Tested on Python 3.12/macOS.
