### PR TITLE
Preserve custom Iter sentinels when chaining operations

### DIFF
--- a/glom/streaming.py
+++ b/glom/streaming.py
@@ -113,7 +113,8 @@ class Iter:
         return
 
     def _add_op(self, opname, args, callback):
-        return type(self)(subspec=self.subspec, _iter_stack=[(opname, args, callback)] + self._iter_stack)
+        return type(self)(subspec=self.subspec, sentinel=self.sentinel,
+                          _iter_stack=[(opname, args, callback)] + self._iter_stack)
 
     def map(self, subspec):
         """Return a new :class:`Iter()` spec which will apply the provided

--- a/glom/test/test_streaming.py
+++ b/glom/test/test_streaming.py
@@ -25,6 +25,42 @@ def test_iter():
         Iter(nonexistent_kwarg=True)
 
 
+@pytest.mark.parametrize('sentinel', [None, object()], ids=['none', 'object'])
+@pytest.mark.parametrize('add_ops, expected', [
+    (lambda spec: spec.map(str), ['0', '1']),
+    (lambda spec: spec.filter(), [1]),
+    (lambda spec: spec.map(str).filter(lambda x: x == '1').chunked(2), [['1']]),
+], ids=['map', 'filter', 'chain'])
+def test_iter_sentinel_chained(sentinel, add_ops, expected):
+    spec = Iter(sentinel=sentinel)
+    chained = add_ops(spec)
+    target = iter([0, SKIP, 1, sentinel, 2])
+
+    assert list(glom(target, chained)) == expected
+    assert list(target) == [2]
+    assert list(glom([0, SKIP, 1, sentinel, 2], spec)) == [0, 1]
+    assert list(glom([0, SKIP, 1, STOP, 2], chained)) == expected
+
+
+def test_iter_sentinel_chained_subspec():
+    target = iter([{'value': 1}, {'value': None}, {'value': 2}])
+    spec = Iter('value', sentinel=None).map(str)
+
+    assert list(glom(target, spec)) == ['1']
+    assert list(target) == [{'value': 2}]
+
+
+def test_iter_sentinel_chained_identity():
+    sentinel = []
+    equal_value = []
+    target = iter([equal_value, sentinel, [1]])
+    result = list(glom(target, Iter(sentinel=sentinel).map(T)))
+
+    assert len(result) == 1
+    assert result[0] is equal_value
+    assert list(target) == [[1]]
+
+
 def test_filter():
     is_odd = lambda x: x % 2
     odd_spec = Iter().filter(is_odd)


### PR DESCRIPTION
Chaining an operation currently resets an `Iter`'s custom sentinel to `STOP`. For example, `Iter(sentinel=None).map(str)` yields `'None'` and continues consuming input after the marker.

Preserve the original sentinel when constructing the chained spec, so mapping, filtering, and longer operation chains stop at the same boundary as the original `Iter`:

```python
from glom import Iter, glom

target = iter([1, None, 2])
list(glom(target, Iter(sentinel=None).map(str)))  # ['1']
list(target)  # [2]
```

Regression tests cover `None` and object sentinels, multiple operations, a non-default subspec, identity comparison, retained input after the sentinel, reuse of the original spec, and existing `SKIP`/`STOP` behavior. All eight new cases fail before the fix.

Validation on Python 3.13.14 with pytest 7.4.4:

- `python -m pytest -q glom/test/test_streaming.py`: 21 passed.
- `python -m pytest -q --doctest-modules glom`: 274 passed, 2 skipped; one existing wildcard-behavior warning.
- `git diff --check`: clean.