### PR TITLE
Make failed negation catchable as a match failure

### DIFF
--- a/glom/matching.py
+++ b/glom/matching.py
@@ -366,7 +366,7 @@ class Not(_Bool):
         except GlomError:
             return target
         else:
-            raise GlomError("child shouldn't have passed", self.child)
+            raise MatchError("child shouldn't have passed: {0!r}", self.child)
 
     def _m_repr(self):
         if isinstance(self.child, (_MType, _MExpr)):

--- a/glom/test/test_match.py
+++ b/glom/test/test_match.py
@@ -508,3 +508,9 @@ def test_switch():
 
 def test_nested_dict():
     assert glom({1: 2}, Match({A.t: S.t})) == {1: 1}
+
+
+@pytest.mark.parametrize('spec', [Not(Match(int)), ~M, ~(M > 0)])
+def test_not_raises_match_error_when_child_matches(spec):
+    with pytest.raises(MatchError):
+        glom(1, spec)


### PR DESCRIPTION
`Not` documents `MatchError` when its child succeeds, but currently raises the generic `GlomError`. As a result, callers handling validation failures with `except MatchError` fail to catch rejected values from `Not`, `~M`, and inverted M comparisons.

Raise `MatchError` at that rejection point and use its formatting convention to retain the child in the diagnostic. The branch that returns the target when the child fails is unchanged.

Validation:
- Added three public `glom()` regression cases for `Not(Match(int))`, `~M`, and `~(M > 0)`: all three fail before the fix and pass afterward.
- With the project's pinned `requirements.txt`: 269 tests/doctests passed, 2 skipped on Python 3.12.
- Manually verified catching `MatchError`, returning the original target for a failed child, `Match(..., default=...)`, and successful inverted M specs.

AI disclosure: This patch and its tests were prepared with OpenAI Codex assistance. The before/after failures, full suite, and public API scenarios were executed locally.
